### PR TITLE
Feature/mail verify cancel

### DIFF
--- a/src/css/mail-verified-incomplete.css
+++ b/src/css/mail-verified-incomplete.css
@@ -4,6 +4,8 @@
 @media (orientation: landscape) {
   .mail-verified-incomplete {
     --padding: 5vh;
+    --control-button-width: calc(var(--responsive-font-size) * 10);
+    --control-button-height: calc(var(--responsive-font-size) * 3);
     width: var(--screen-width);
     height: var(--screen-height);
     box-sizing: border-box;
@@ -31,4 +33,23 @@
 
 .mail-verified-incomplete__procedure {
   padding-bottom: var(--responsive-font-size);
+}
+
+.mail-verified-incomplete__controllers button {
+  width: var(--control-button-width);
+  height: var(--control-button-height);
+  font-size: var(--responsive-font-size);
+  border-radius: var(--button-border-radius);
+  color: var(--button-font-color);
+  border: var(--button-border);
+  box-shadow: var(--button-box-shadow);
+}
+
+.mail-verified-incomplete__controllers__goto-title {
+  background-color: var(--sub-button-background-color);
+  margin-right: var(--responsive-font-size);
+}
+
+.mail-verified-incomplete__controllers__reload {
+  background-color: var(--button-background-color);
 }

--- a/src/css/mail-verified-incomplete.css
+++ b/src/css/mail-verified-incomplete.css
@@ -47,7 +47,7 @@
 
 .mail-verified-incomplete__controllers__goto-title {
   background-color: var(--sub-button-background-color);
-  margin-right: var(--responsive-font-size);
+  margin-right: calc(var(--responsive-font-size) * 0.5);
 }
 
 .mail-verified-incomplete__controllers__reload {

--- a/src/js/game/actions/game-actions.js
+++ b/src/js/game/actions/game-actions.js
@@ -4,6 +4,16 @@ import type {ArmDozerId, GameEnd, PilotId} from "gbraver-burst-core";
 import type {PostNetworkError} from '../network/post-network-error';
 import type {NPCBattleCourseDifficulty} from "../npc-battle/npc-battle-course";
 
+/** 画面リロード依頼 */
+export type ReloadRequest = {
+  type: 'ReloadRequest'
+}
+
+/** メール認証未完了画面を抜ける */
+export type ExitMailVerifiedIncomplete = {
+  type: 'ExitMailVerifiedIncomplete'
+}
+
 /** ゲームスタート */
 export type GameStart = {
   type: 'GameStart'
@@ -131,7 +141,9 @@ export type EndNetworkError = {
 /**
  * ゲーム全体で利用するアクション
  */
-export type GameAction = GameStart
+export type GameAction = ReloadRequest
+ | ExitMailVerifiedIncomplete
+ | GameStart
  | CasualMatchStart
  | ShowHowToPlay
  | EndHowToPlay

--- a/src/js/game/dom-scenes/index.js
+++ b/src/js/game/dom-scenes/index.js
@@ -65,6 +65,15 @@ export class DOMScenes {
 
     const scene = new MailVerifiedIncomplete(mailAddress);
     this._root.appendChild(scene.getRootHTMLElement());
+    this._unsubscribers = [
+      scene.gotoTitleNotifier().subscribe(() => {
+        this._gameAction.next({type: 'ExitMailVerifiedIncomplete'});
+      }),
+      scene.reloadNotifier().subscribe(() => {
+        this._gameAction.next({type: 'ReloadRequest'});
+      })
+    ];
+
     this._scene = scene;
     return scene;
   }

--- a/src/js/game/dom-scenes/mail-verified-incomplete/mail-verified-incomplete.js
+++ b/src/js/game/dom-scenes/mail-verified-incomplete/mail-verified-incomplete.js
@@ -2,6 +2,7 @@
 
 import type {DOMScene} from "../dom-scene";
 import {escapeHTML} from "../../../dom/escape/escape-html";
+import type {StreamSource} from "../../../stream/core";
 
 /** ルート要素 class属性 */
 const ROOT_CLASS = 'mail-verified-incomplete';
@@ -22,6 +23,10 @@ function rootInnerHTML(mailAddress: string): string {
       <li class="${ROOT_CLASS}__procedure__item">認証メールに記載されたVerify Linkを開く</li>
       <li class="${ROOT_CLASS}__procedure__item">Gブレイバーバーストを再読み込みする</li>
     </ol>
+    <div class="${ROOT_CLASS}__controllers">
+      <button class="${ROOT_CLASS}__controllers__goto-title">タイトルへ</button>
+      <button class="${ROOT_CLASS}__controllers__reload">再読み込み</button>
+    </div>
   `;
 }
 

--- a/src/js/game/dom-scenes/mail-verified-incomplete/mail-verified-incomplete.js
+++ b/src/js/game/dom-scenes/mail-verified-incomplete/mail-verified-incomplete.js
@@ -2,18 +2,28 @@
 
 import type {DOMScene} from "../dom-scene";
 import {escapeHTML} from "../../../dom/escape/escape-html";
-import type {StreamSource} from "../../../stream/core";
+import {domUuid} from "../../../uuid/dom-uuid";
+import {pushDOMStream} from "../../../dom/push/push-dom";
+import type {Unsubscriber} from "../../../stream/core";
+import type {PushDOM} from "../../../dom/push/push-dom";
 
 /** ルート要素 class属性 */
 const ROOT_CLASS = 'mail-verified-incomplete';
 
+/** data-idを集めたもの */
+type DataIDs = {
+  gotoTitle: string,
+  reload: string,
+};
+
 /**
  * ルート要素のinnerHTML
  *
+ * @param ids data-idを集めたもの
  * @param mailAddress メールアドレス
  * @return ルート要素innerHTML
  */
-function rootInnerHTML(mailAddress: string): string {
+function rootInnerHTML(ids: DataIDs, mailAddress: string): string {
   const escapedMailAddress = escapeHTML(mailAddress);
   return `
     <div class="${ROOT_CLASS}__title">メール認証を完了させてください</div>
@@ -24,15 +34,37 @@ function rootInnerHTML(mailAddress: string): string {
       <li class="${ROOT_CLASS}__procedure__item">Gブレイバーバーストを再読み込みする</li>
     </ol>
     <div class="${ROOT_CLASS}__controllers">
-      <button class="${ROOT_CLASS}__controllers__goto-title">タイトルへ</button>
-      <button class="${ROOT_CLASS}__controllers__reload">再読み込み</button>
+      <button class="${ROOT_CLASS}__controllers__goto-title" data-id="${ids.gotoTitle}">タイトルへ</button>
+      <button class="${ROOT_CLASS}__controllers__reload" data-id="${ids.reload}">再読み込み</button>
     </div>
   `;
+}
+
+/** ルート要素の子孫要素 */
+type Elements = {
+  gotoTitle: HTMLElement,
+  reload: HTMLElement,
+};
+
+/**
+ * ルート要素から子孫要素を抽出する
+ *
+ * @param root ルート要素
+ * @param ids data-idを集めたもの
+ * @return 抽出結果
+ */
+function extractElements(root: HTMLElement, ids: DataIDs): Elements {
+  const gotoTitle = root.querySelector(`[data-id="${ids.gotoTitle}"]`) ?? document.createElement('div');
+  const reload = root.querySelector(`[data-id="${ids.reload}"]`) ?? document.createElement('div');
+  return {gotoTitle, reload};
 }
 
 /** メール認証未完了画面 */
 export class MailVerifiedIncomplete implements DOMScene {
   _root: HTMLElement;
+  _gotoTitleButton: HTMLElement;
+  _reloadButton: HTMLElement;
+  _unsubscribers: Unsubscriber[];
 
   /**
    * コンストラクタ
@@ -40,18 +72,56 @@ export class MailVerifiedIncomplete implements DOMScene {
    * @param mailAddress 認証メール送信先アドレス
    */
   constructor(mailAddress: string): void {
+    const ids = {gotoTitle: domUuid(), reload: domUuid()};
     this._root = document.createElement('div');
     this._root.className = ROOT_CLASS;
-    this._root.innerHTML = rootInnerHTML(mailAddress);
+    this._root.innerHTML = rootInnerHTML(ids, mailAddress);
+
+    const elements = extractElements(this._root, ids);
+    this._gotoTitleButton = elements.gotoTitle;
+    this._reloadButton = elements.reload;
+
+    this._unsubscribers = [
+      pushDOMStream(this._gotoTitleButton).subscribe(action => {
+        this._onGotoTitleButtonPush(action);
+      }),
+      pushDOMStream(this._reloadButton).subscribe(action => {
+        this._onReloadButtonPush(action);
+      }),
+    ];
   }
-  
+
   /** @override */
   destructor(): void {
-    // NOP
+    this._unsubscribers.forEach(v => {
+      v.unsubscribe();
+    });
   }
 
   /** @override  */
   getRootHTMLElement(): HTMLElement {
     return this._root;
+  }
+
+  /**
+   * タイトルへボタンが押された時の処理
+   *
+   * @param action アクション
+   */
+  _onGotoTitleButtonPush(action: PushDOM): void {
+    action.event.preventDefault();
+    action.event.stopPropagation();
+    console.log('goto title.');
+  }
+
+  /**
+   * 再読み込みボタンが押された時の処理
+   *
+   * @param action アクション
+   */
+  _onReloadButtonPush(action: PushDOM): void {
+    action.event.preventDefault();
+    action.event.stopPropagation();
+    console.log('reload.');
   }
 }

--- a/src/js/game/index.js
+++ b/src/js/game/index.js
@@ -152,7 +152,9 @@ export class Game {
     const gameActionStreams = [this._tdScenes.gameActionNotifier(), this._domScenes.gameActionNotifier(),
       this._domDialogs.gameActionNotifier(), suddenlyBattleEnd, webSocketAPIError, WebSocketAPIUnintentionalClose];
     this._unsubscriber = gameActionStreams.map(v => v.subscribe(action => {
-      if (action.type === 'EndBattle') { this._onEndBattle(action) }
+      if (action.type === 'ReloadRequest') { this._onReloadRequest() }
+      else if (action.type === 'ExitMailVerifiedIncomplete') { this._onExitMailVerifiedIncomplete() }
+      else if (action.type === 'EndBattle') { this._onEndBattle(action) }
       else if (action.type === 'SuddenlyBattleEnd') { this._onSuddenlyEndBattle() }
       else if (action.type === 'GameStart') { this._onGameStart() }
       else if (action.type === 'CasualMatchStart') { this._onCasualMatchStart() }
@@ -212,7 +214,28 @@ export class Game {
   }
 
   /**
+   * 画面リロード依頼時の処理
+   *
+   * @return 処理が完了したら発火するPromise
+   */
+  async _onReloadRequest(): Promise<void> {
+    await this._fader.fadeOut();
+    window.location.reload();
+  }
+
+  /**
+   * メール認証未完了画面を抜ける時の処理
+   *
+   * @return 処理が完了したら発火するPromise
+   */
+  async _onExitMailVerifiedIncomplete(): Promise<void> {
+    await this._fader.fadeOut();
+    await this._api.logout();
+  }
+
+  /**
    * ゲームスタート時の処理
+   * @return 処理が完了したら発火するPromise
    */
   async _onGameStart(): Promise<void> {
     if (!this._resources) {

--- a/stories/mail-verified-incomplete.stories.js
+++ b/stories/mail-verified-incomplete.stories.js
@@ -10,5 +10,11 @@ export default {
 
 export const scene: DOMStubStory = domStub(() => {
   const scene = new MailVerifiedIncomplete('test@mail.address.com');
+  scene.gotoTitleNotifier().subscribe(() => {
+    console.log('goto title');
+  });
+  scene.reloadNotifier().subscribe(() => {
+    console.log('reload');
+  });
   return scene.getRootHTMLElement();
 });


### PR DESCRIPTION
メール認証未完了画面に各種ボタンを追加した

変更前の仕様では、認証用メールを送信できなかった場合に、セッションが切れるまでメール認証未完了画面から移動できない不具合があった。
対策として、「タイトルへ」ボタンでタイトル画面に遷移できるようにした。
また、利便性向上のために画面リロードボタンも追加した。