### PR TITLE
TextureConfigsのフォルダ構成を変更

### DIFF
--- a/src/js/resource/texture/configs/genesis-braver.ts
+++ b/src/js/resource/texture/configs/genesis-braver.ts
@@ -1,5 +1,5 @@
-import { TEXTURE_IDS } from "./ids";
-import { TextureConfig } from "./resource";
+import { TEXTURE_IDS } from "../ids";
+import { TextureConfig } from "../resource";
 
 /** ジェネシスブレイバーのテクスチャ設定をあつめたもの */
 export const GenesisBraverTextureConfigs: TextureConfig[] = [

--- a/src/js/resource/texture/configs/index.ts
+++ b/src/js/resource/texture/configs/index.ts
@@ -1,8 +1,8 @@
+import { TEXTURE_IDS } from "../ids";
+import type { TextureConfig } from "../resource";
 import { GenesisBraverTextureConfigs } from "./genesis-braver";
-import { TEXTURE_IDS } from "./ids";
 import { LightningDozerTextureConfigs } from "./lightning-dozer";
 import { NeoLandozerTextureConfigs } from "./neo-landozer";
-import type { TextureConfig } from "./resource";
 import { ShinBraverTextureConfigs } from "./shin-braver";
 import { WingDozerTextureConfigs } from "./wing-dozer";
 

--- a/src/js/resource/texture/configs/lightning-dozer.ts
+++ b/src/js/resource/texture/configs/lightning-dozer.ts
@@ -1,5 +1,5 @@
-import { TEXTURE_IDS } from "./ids";
-import { TextureConfig } from "./resource";
+import { TEXTURE_IDS } from "../ids";
+import { TextureConfig } from "../resource";
 
 /** ライトニングドーザのテクスチャ設定をまとめたもの */
 export const LightningDozerTextureConfigs: TextureConfig[] = [

--- a/src/js/resource/texture/configs/neo-landozer.ts
+++ b/src/js/resource/texture/configs/neo-landozer.ts
@@ -1,5 +1,5 @@
-import { TEXTURE_IDS } from "./ids";
-import { TextureConfig } from "./resource";
+import { TEXTURE_IDS } from "../ids";
+import { TextureConfig } from "../resource";
 
 /** ネオランドーザのテクスチャ設定をあつめたもの */
 export const NeoLandozerTextureConfigs: TextureConfig[] = [

--- a/src/js/resource/texture/configs/shin-braver.ts
+++ b/src/js/resource/texture/configs/shin-braver.ts
@@ -1,5 +1,5 @@
-import { TEXTURE_IDS } from "./ids";
-import { TextureConfig } from "./resource";
+import { TEXTURE_IDS } from "../ids";
+import { TextureConfig } from "../resource";
 
 /** シンブレイバーのテクスチャ設定をあつめたもの */
 export const ShinBraverTextureConfigs: TextureConfig[] = [

--- a/src/js/resource/texture/configs/wing-dozer.ts
+++ b/src/js/resource/texture/configs/wing-dozer.ts
@@ -1,5 +1,5 @@
-import { TEXTURE_IDS } from "./ids";
-import { TextureConfig } from "./resource";
+import { TEXTURE_IDS } from "../ids";
+import { TextureConfig } from "../resource";
 
 /** ウィングドーザのテクスチャ設定をあつめたもの */
 export const WingDozerTextureConfigs: TextureConfig[] = [


### PR DESCRIPTION
循環importはありません。
```shell
vagrant@ubuntu-focal:~/gbraver-burst/gbraver-burst-browser$ madge --extensions ts -c src
Processed 1174 files (4.4s) (150 warnings)

✔ No circular dependency found!

vagrant@ubuntu-focal:~/gbraver-burst/gbraver-burst-browser$ madge --extensions ts -c test/
Processed 87 files (905ms) (5 warnings)

✔ No circular dependency found!

vagrant@ubuntu-focal:~/gbraver-burst/gbraver-burst-browser$ madge --extensions ts -c stories/
Processed 340 files (1.9s) (92 warnings)

✔ No circular dependency found!
```