### PR TITLE
グランドーザのノックバック復帰モーションを調整した

### DIFF
--- a/src/js/game-object/armdozer/gran-dozer/animation/knock-back-to-stand.ts
+++ b/src/js/game-object/armdozer/gran-dozer/animation/knock-back-to-stand.ts
@@ -16,7 +16,7 @@ export function knockBackToStand(props: GranDozerAnimationProps): Animate {
       se.play(sounds.motor);
     }),
   )
-    .chain(tween(model.animation, (t) => t.to({ frame: 0 }, 200)))
+    .chain(tween(model.animation, (t) => t.to({ frame: 0 }, 250)))
     .chain(
       tween(model.animation, (t) =>
         t
@@ -35,15 +35,15 @@ export function knockBackToStand(props: GranDozerAnimationProps): Animate {
           .to({ frame: 0 }, 0),
       ),
     )
-    .chain(tween(model.animation, (t) => t.to({ frame: 1 }, 200)))
-    .chain(delay(100))
+    .chain(tween(model.animation, (t) => t.to({ frame: 1 }, 250)))
+    .chain(delay(200))
     .chain(
       tween(model.animation, (t) =>
         t
           .onStart(() => {
             se.play(sounds.motor);
           })
-          .to({ frame: 0 }, 200)
+          .to({ frame: 0 }, 300)
           .onComplete(() => {
             model.animation.type = "STAND";
           }),


### PR DESCRIPTION
This pull request includes changes to the `knockBackToStand` function in the `src/js/game-object/armdozer/gran-dozer/animation/knock-back-to-stand.ts` file. The changes primarily involve adjustments to the timing of animation frames.

Timing adjustments:

* Increased the duration of the initial tween from 200ms to 250ms.
* Increased the duration of the second tween from 200ms to 250ms and the subsequent delay from 100ms to 200ms.
* Increased the duration of the final tween from 200ms to 300ms.