### PR TITLE
ep6.2のセリフを追加

### DIFF
--- a/src/js/custom-battle-events/prince-of-fallen-sun/animation/gai-battle-shout-when-hit.ts
+++ b/src/js/custom-battle-events/prince-of-fallen-sun/animation/gai-battle-shout-when-hit.ts
@@ -1,0 +1,16 @@
+import { onStart } from "../../../animation/on-start";
+import { wbr } from "../../../dom/wbr";
+import { CustomBattleEventProps } from "../../../td-scenes/battle/custom-battle-event";
+import { enemyPilotOnlyShout } from "../../pilot-shout";
+
+/**
+ * ガイ 戦闘 ヒット
+ * @param props イベントプロパティ
+ * @returns アニメーション
+ */
+export const gaiBattleShoutWhenHit = (
+  props: Readonly<CustomBattleEventProps>,
+) =>
+  onStart(() => {
+    enemyPilotOnlyShout(props, "Gai", `よし 手応え${wbr}ありだ`);
+  });

--- a/src/js/custom-battle-events/prince-of-fallen-sun/procedure/on-state-animation/gai-battle-when-hit.ts
+++ b/src/js/custom-battle-events/prince-of-fallen-sun/procedure/on-state-animation/gai-battle-when-hit.ts
@@ -1,0 +1,37 @@
+import { Animate } from "../../../../animation/animate";
+import { empty } from "../../../../animation/delay";
+import { CustomStateAnimationProps } from "../../../../td-scenes/battle/custom-battle-event";
+import { ConditionalAnimation } from "../../../get-animation-if-conditional-met";
+import { gaiBattleShoutWhenHit } from "../../animation/gai-battle-shout-when-hit";
+import { PrinceOfFallenSunProps } from "../../props";
+
+/** ガイ 戦闘 ヒット */
+export const gaiBattleWhenHit: ConditionalAnimation<
+  CustomStateAnimationProps & PrinceOfFallenSunProps
+> = (props) => {
+  let result: Animate | null = null;
+
+  const { update, currentState, enemyId } = props;
+  const { effect } = currentState;
+  const hasEnemyGuard = update.some(
+    (s) =>
+      s.effect.name === "Battle" &&
+      s.effect.attacker === enemyId &&
+      s.effect.result.name === "NormalHit",
+  );
+  if (
+    hasEnemyGuard &&
+    effect.name === "BatteryDeclaration" &&
+    effect.attacker === enemyId
+  ) {
+    result = gaiBattleShoutWhenHit(props);
+  } else if (
+    hasEnemyGuard &&
+    effect.name === "Battle" &&
+    effect.attacker === enemyId
+  ) {
+    result = empty();
+  }
+
+  return result;
+};

--- a/src/js/custom-battle-events/prince-of-fallen-sun/procedure/on-state-animation/index.ts
+++ b/src/js/custom-battle-events/prince-of-fallen-sun/procedure/on-state-animation/index.ts
@@ -5,6 +5,7 @@ import { getAnimationIfConditionMet } from "../../../get-animation-if-conditiona
 import { invisibleShoutMessageWindowWhenTurnChange } from "../../../invisible-shout-message-window";
 import { PrinceOfFallenSunProps } from "../../props";
 import { gaiBattleWhenGuard } from "./gai-battle-when-guard";
+import { gaiBattleWhenHit } from "./gai-battle-when-hit";
 import { gaiBattleWhenMiss } from "./gai-battle-when-miss";
 import { gaiBurst } from "./gai-burst";
 import { gaiFeintSuccess } from "./gai-feint-success";
@@ -50,6 +51,7 @@ export function onStateAnimation(
     gaiFeintSuccess,
     gaiFirstAttack,
     gaiSecondAttack,
+    gaiBattleWhenHit,
     gaiBattleWhenGuard,
     gaiBattleWhenMiss,
     invisibleShoutMessageWindowWhenTurnChange,


### PR DESCRIPTION
This pull request introduces a new animation and conditional logic for the "Gai Battle When Hit" event in the `Prince of Fallen Sun` custom battle events. The changes include defining the animation logic, adding conditional checks, and integrating the new event into the existing animation procedures.

### New Animation and Logic for "Gai Battle When Hit":

* **Definition of `gaiBattleShoutWhenHit` Animation**:
  - Added a new function `gaiBattleShoutWhenHit` in `gai-battle-shout-when-hit.ts` to handle the animation where Gai shouts upon hitting an enemy. This uses `onStart` to trigger the shout and incorporates a line break (`wbr`) for better text formatting.

* **Conditional Logic for `gaiBattleWhenHit`**:
  - Introduced `gaiBattleWhenHit` in `gai-battle-when-hit.ts`, which determines the animation to play based on the current state and enemy actions. It checks for conditions such as "NormalHit" and "BatteryDeclaration" to decide whether to trigger the shout animation or return an empty animation.

### Integration into Existing Animation Procedures:

* **Import Statement Update**:
  - Added `gaiBattleWhenHit` to the imports in `on-state-animation/index.ts` to make it available in the animation procedure.

* **Procedure Registration**:
  - Registered `gaiBattleWhenHit` in the `onStateAnimation` function, ensuring it is included in the list of animations to be executed during the battle state updates.