### PR TITLE
修正: three.jsレンダラに高性能設定を追加

### DIFF
--- a/src/js/render/index.ts
+++ b/src/js/render/index.ts
@@ -28,7 +28,9 @@ export class Renderer implements OverlapNotifier, RendererDomGetter, Rendering {
    * @param resize リサイズのストリーム
    */
   constructor(resize: Observable<Resize>) {
-    this.#threeJsRender = new THREE.WebGLRenderer();
+    this.#threeJsRender = new THREE.WebGLRenderer({
+      powerPreference: "high-performance",
+    });
     this.#threeJsRender.outputColorSpace = THREE.LinearSRGBColorSpace;
     this.#threeJsRender.autoClear = false;
 

--- a/stories/stub/still-image-stub.ts
+++ b/stories/stub/still-image-stub.ts
@@ -102,7 +102,9 @@ export const stillImageStub =
   () => {
     const ref = React.useRef<HTMLDivElement>(null);
     React.useEffect(() => {
-      const renderer = new THREE.WebGLRenderer();
+      const renderer = new THREE.WebGLRenderer({
+        powerPreference: "high-performance",
+      });
       const { pixelRatio, width, height } = params.renderer;
       renderer.setPixelRatio(pixelRatio);
       renderer.setSize(width, height);


### PR DESCRIPTION
This pull request improves rendering performance by configuring the `THREE.WebGLRenderer` to prioritize high-performance rendering. The changes affect both the main renderer and a stub used in testing or stories.

### Renderer performance improvements:

* [`src/js/render/index.ts`](diffhunk://#diff-359532e9bd7d22600383c20f28f24545f026dfeaf7d577d0aa05b5047f608368L31-R33): Updated the `Renderer` class to initialize `THREE.WebGLRenderer` with the `powerPreference: "high-performance"` option, optimizing for better GPU performance.
* [`stories/stub/still-image-stub.ts`](diffhunk://#diff-a70d39fe496281f23d368ab0d433d701a15c5f7770612ef057332c999ba5d242L105-R107): Modified the `stillImageStub` to create a `THREE.WebGLRenderer` instance with the `powerPreference: "high-performance"` option, ensuring consistent performance improvements in test setups.