### PR TITLE
チュートリアル開始ボタンに絵文字を追加

### DIFF
--- a/src/js/dom-dialogs/tutorial-description/dom/root-inner-html.hbs
+++ b/src/js/dom-dialogs/tutorial-description/dom/root-inner-html.hbs
@@ -12,6 +12,6 @@
   <button
     class="{{ROOT}}__start-tutorial"
     data-id="start-tutorial"
-  >チュートリアルをはじめる</button>
+  >🔰チュートリアルをはじめる</button>
   <button class="{{ROOT}}__close" data-id="close">閉じる</button>
 </div>


### PR DESCRIPTION
This pull request includes a small change to the `src/js/dom-dialogs/tutorial-description/dom/root-inner-html.hbs` file. The change updates the text of the "Start Tutorial" button to include an emoji for better visual emphasis.