### PR TITLE
ステータスダイアログ本体を押しても閉じないようにした

### DIFF
--- a/src/js/dom-dialogs/status/dom/extract-element.ts
+++ b/src/js/dom-dialogs/status/dom/extract-element.ts
@@ -9,3 +9,11 @@ export const extractCloser = (root: HTMLElement): HTMLImageElement => {
     ? extracted
     : document.createElement("img");
 };
+
+/**
+ * バックグラウンド要素を抽出する
+ * @param root ルート要素
+ * @returns バックグラウンド要素
+ */
+export const extractBackGround = (root: HTMLElement): HTMLElement =>
+  root.querySelector('[data-id="background"]') ?? document.createElement("div");

--- a/src/js/dom-dialogs/status/dom/root-inner-html.hbs
+++ b/src/js/dom-dialogs/status/dom/root-inner-html.hbs
@@ -1,4 +1,4 @@
-<div class="status__background"></div>
+<div class="status__background" data-id="background"></div>
 <div class="status__dialog">
   <img
     class="status__closer"

--- a/src/js/dom-dialogs/status/procedures/bind-event-listeners.ts
+++ b/src/js/dom-dialogs/status/procedures/bind-event-listeners.ts
@@ -2,8 +2,8 @@ import { Unsubscribable } from "rxjs";
 
 import { domPushStream } from "../../../dom/push-dom";
 import { StatusDialogProps } from "../props";
+import { onBackGroundPush } from "./on-back-ground-push";
 import { onCloserPush } from "./on-closer-push";
-import { onRootPush } from "./on-root-push";
 
 /**
  * イベントリスナーをバインドする
@@ -15,8 +15,8 @@ export function bindEventListeners(props: StatusDialogProps): Unsubscribable[] {
     domPushStream(props.closer).subscribe((action) => {
       onCloserPush({ props, action });
     }),
-    domPushStream(props.root).subscribe((action) => {
-      onRootPush({ props, action });
+    domPushStream(props.background).subscribe((action) => {
+      onBackGroundPush({ props, action });
     }),
   ];
 }

--- a/src/js/dom-dialogs/status/procedures/create-status-dialog-props.ts
+++ b/src/js/dom-dialogs/status/procedures/create-status-dialog-props.ts
@@ -5,7 +5,7 @@ import { createEmptySoundResource } from "../../../resource/sound/empty-sound-re
 import { SOUND_IDS } from "../../../resource/sound/ids";
 import { SEPlayerContainer } from "../../../se/se-player";
 import { ROOT } from "../dom/class-name";
-import { extractCloser } from "../dom/extract-element";
+import { extractBackGround, extractCloser } from "../dom/extract-element";
 import { rootInnerHTML, RootInnerHTMLOptions } from "../dom/root-inner-html";
 import { StatusDialogProps } from "../props";
 
@@ -25,6 +25,7 @@ export function createStatusDialogProps(
   root.className = ROOT;
   root.innerHTML = rootInnerHTML(options);
   const closer = extractCloser(root);
+  const background = extractBackGround(root);
 
   const exclusive = new Exclusive();
 
@@ -39,6 +40,7 @@ export function createStatusDialogProps(
 
     root,
     closer,
+    background,
 
     exclusive,
 

--- a/src/js/dom-dialogs/status/procedures/on-back-ground-push.ts
+++ b/src/js/dom-dialogs/status/procedures/on-back-ground-push.ts
@@ -2,10 +2,10 @@ import { PushDOM } from "../../../dom/push-dom";
 import { StatusDialogProps } from "../props";
 
 /**
- * ルート要素が押されたときの処理
+ * バックグラウンド要素が押されたときの処理
  * @param options オプション
  */
-export function onRootPush(options: {
+export function onBackGroundPush(options: {
   /** ステータスダイアログのプロパティ */
   props: StatusDialogProps;
   /** アクション */

--- a/src/js/dom-dialogs/status/props.ts
+++ b/src/js/dom-dialogs/status/props.ts
@@ -10,6 +10,8 @@ export type StatusDialogProps = SEPlayerContainer & {
   readonly root: HTMLElement;
   /** クローザー要素 */
   readonly closer: HTMLImageElement;
+  /** バックグラウンド要素 */
+  readonly background: HTMLElement;
 
   /** 排他制御 */
   readonly exclusive: Exclusive;


### PR DESCRIPTION
This pull request refactors how the status dialog handles its background element by introducing a dedicated background property and associated logic. The changes improve clarity and separation of concerns in the codebase, making it easier to manage background-related behavior separately from the root element.

**Background element extraction and event handling:**

* Added a new `extractBackGround` function to extract the background element from the dialog's root, identified by a `data-id="background"` attribute. (`src/js/dom-dialogs/status/dom/extract-element.ts`)
* Updated the dialog's HTML template to add a `data-id="background"` attribute to the background element, enabling reliable selection. (`src/js/dom-dialogs/status/dom/root-inner-html.hbs`)

**Dialog property and event listener updates:**

* Extended `StatusDialogProps` to include a new `background` property for the background element. (`src/js/dom-dialogs/status/props.ts`)
* Modified `createStatusDialogProps` to extract and assign the background element using the new function. (`src/js/dom-dialogs/status/procedures/create-status-dialog-props.ts`) [[1]](diffhunk://#diff-ff40133d7d32332a8cf5a73a86d6fdbc2bca9a6c4a54382720dcaaef8b3b4697L8-R8) [[2]](diffhunk://#diff-ff40133d7d32332a8cf5a73a86d6fdbc2bca9a6c4a54382720dcaaef8b3b4697R28) [[3]](diffhunk://#diff-ff40133d7d32332a8cf5a73a86d6fdbc2bca9a6c4a54382720dcaaef8b3b4697R43)
* Updated event listener binding to listen for background element actions instead of root, and renamed the handler from `onRootPush` to `onBackGroundPush` for clarity. (`src/js/dom-dialogs/status/procedures/bind-event-listeners.ts`, `src/js/dom-dialogs/status/procedures/on-back-ground-push.ts`) [[1]](diffhunk://#diff-0fb416b47252c727f1e8cdfdc45b0af8e0dad94912db361742bd8a2923283a34R5-L6) [[2]](diffhunk://#diff-0fb416b47252c727f1e8cdfdc45b0af8e0dad94912db361742bd8a2923283a34L18-R19) [[3]](diffhunk://#diff-47925cc24e6dca6e3e2aa5a437c67257efb383bcf6e3905f3645c925123b6124L5-R8)