### PR TITLE
バトルシュミレーターアイコンの位置を調整

### DIFF
--- a/src/js/game-object/predicated-damage/view/predicated-damage-view.ts
+++ b/src/js/game-object/predicated-damage/view/predicated-damage-view.ts
@@ -40,6 +40,9 @@ const BATTLE_SIMULATOR_ICON_SIZE = 70;
 /** 数字とアイコンの間のマージン */
 const NUMBER_TO_ICON_MARGIN = 2;
 
+/** バトルシミュレーターアイコンのY位置 */
+const BATTLE_SIMULATOR_ICON_Y = 2;
+
 /** コンストラクタのパラメータ */
 export type PredicatedDamageViewConstructParams = ResourcesContainer &
   GameObjectActionContainer;
@@ -161,7 +164,10 @@ export class PredicatedDamageView {
       (intervalCount / 2) * NUMBER_MESH_INTERVAL +
       BATTLE_SIMULATOR_ICON_SIZE / 2 +
       NUMBER_TO_ICON_MARGIN;
+
     this.#battleSimulatorIcon.getObject3D().position.x = battleSimulatorIconX;
+    this.#battleSimulatorIcon.getObject3D().position.y =
+      BATTLE_SIMULATOR_ICON_Y;
     this.#battleSimulatorIcon
       .getObject3D()
       .scale.set(
@@ -173,6 +179,8 @@ export class PredicatedDamageView {
 
     this.#battleSimulatorIconPushDetector.getObject3D().position.x =
       battleSimulatorIconX;
+    this.#battleSimulatorIconPushDetector.getObject3D().position.y =
+      BATTLE_SIMULATOR_ICON_Y;
   }
 
   /**


### PR DESCRIPTION
This pull request makes a minor adjustment to the vertical positioning of the battle simulator icon and its push detector in the `PredicatedDamageView` component. The change introduces a new constant for the Y position and applies it to both the icon and its interaction detector.

- UI positioning improvements:
  * Added a new constant `BATTLE_SIMULATOR_ICON_Y` to define the Y position of the battle simulator icon, and updated both the icon and its push detector to use this value for consistent vertical alignment. [[1]](diffhunk://#diff-da53fb3fe5eeaf4bec998b5e600661fe05c4986c8d043ca05c820421ddf8e857R43-R45) [[2]](diffhunk://#diff-da53fb3fe5eeaf4bec998b5e600661fe05c4986c8d043ca05c820421ddf8e857R167-R170) [[3]](diffhunk://#diff-da53fb3fe5eeaf4bec998b5e600661fe05c4986c8d043ca05c820421ddf8e857R182-R183)