### PR TITLE
ローカル対戦ゲスト用ダイアログを追加

### DIFF
--- a/src/css/local-battle-guest.css
+++ b/src/css/local-battle-guest.css
@@ -1,0 +1,64 @@
+/** ローカル対戦ゲストダイアログ */
+
+@media (orientation: landscape) {
+  .local-battle-guest {
+    display: block;
+  }
+}
+
+@media (orientation: portrait) {
+  .local-battle-guest {
+    display: none;
+  }
+}
+
+.local-battle-guest__background {
+  position: absolute;
+  width: 100vw;
+  width: 100dvw;
+  height: 100vh;
+  height: 100dvh;
+  background-color: #000;
+  opacity: 0.5;
+  z-index: var(--zindex-background);
+}
+
+.local-battle-guest__dialog {
+  --dialog-padding: calc(var(--responsive-font-size) * 2);
+
+  top: 50vh;
+  top: 50dvh;
+  left: 50vw;
+  left: 50dvw;
+  width: min(
+    calc(
+      100vw - var(--safe-area-right) - var(--safe-area-left) -
+        var(--closer-width) * 0.5
+    ),
+    90vw
+  );
+  min-height: 60vh;
+  transform: translate(-50%, -50%);
+  color: var(--font-color);
+  background-color: var(--background-color);
+  position: absolute;
+  border: var(--dialog-border);
+  border-radius: var(--dialog-border-radius);
+  z-index: var(--zindex-dialog);
+  box-sizing: border-box;
+  padding: max(var(--dialog-padding), calc(var(--closer-height) / 2))
+    var(--dialog-padding) var(--dialog-padding) var(--dialog-padding);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  font-size: calc(var(--responsive-font-size) * 1.2);
+}
+
+.local-battle-guest__closer {
+  width: var(--closer-width);
+  height: var(--closer-height);
+  position: absolute;
+  top: calc(var(--closer-width) * -0.5);
+  left: calc(var(--closer-height) * -0.5);
+}

--- a/src/css/local-battle-guest.css
+++ b/src/css/local-battle-guest.css
@@ -62,7 +62,7 @@
 
 .local-battle-guest__description {
   text-align: center;
-  font-size: calc(var(--responsive-font-size) * 1.3);
+  font-size: calc(var(--responsive-font-size) * 1.2);
   margin-bottom: calc(var(--responsive-font-size) * 0.5);
 }
 

--- a/src/css/local-battle-guest.css
+++ b/src/css/local-battle-guest.css
@@ -47,7 +47,6 @@
   box-sizing: border-box;
   padding: max(var(--dialog-padding), calc(var(--closer-height) / 2))
     var(--dialog-padding) var(--dialog-padding) var(--dialog-padding);
-  font-size: calc(var(--responsive-font-size) * 1.2);
   display: flex;
   flex-direction: column;
   gap: calc(var(--responsive-font-size) * 0.5);
@@ -63,7 +62,7 @@
 
 .local-battle-guest__description {
   text-align: center;
-  font-size: calc(var(--responsive-font-size) * 1.6);
+  font-size: calc(var(--responsive-font-size) * 1.3);
   margin-bottom: calc(var(--responsive-font-size) * 0.5);
 }
 
@@ -74,6 +73,7 @@
   padding: var(--button-border-radius);
   box-sizing: border-box;
   font-size: calc(var(--responsive-font-size) * 1);
+  text-align: center;
 }
 
 .local-battle-guest__battle-start {

--- a/src/css/local-battle-guest.css
+++ b/src/css/local-battle-guest.css
@@ -35,7 +35,7 @@
       100vw - var(--safe-area-right) - var(--safe-area-left) -
         var(--closer-width) * 0.5
     ),
-    90vw
+    80vw
   );
   min-height: 60vh;
   transform: translate(-50%, -50%);
@@ -48,11 +48,12 @@
   box-sizing: border-box;
   padding: max(var(--dialog-padding), calc(var(--closer-height) / 2))
     var(--dialog-padding) var(--dialog-padding) var(--dialog-padding);
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
   font-size: calc(var(--responsive-font-size) * 1.2);
+  display: grid;
+  grid-template:
+    "description description" auto
+    "password battle-start" auto / 1fr auto;
+  gap: calc(var(--responsive-font-size) * 0.5);
 }
 
 .local-battle-guest__closer {
@@ -61,4 +62,34 @@
   position: absolute;
   top: calc(var(--closer-width) * -0.5);
   left: calc(var(--closer-height) * -0.5);
+}
+
+.local-battle-guest__description {
+  grid-area: description;
+  align-self: end;
+  font-size: calc(var(--responsive-font-size) * 2);
+  margin-bottom: calc(var(--responsive-font-size) * 2);
+}
+
+.local-battle-guest__password {
+  grid-area: password;
+  align-self: start;
+  height: calc(var(--responsive-font-size) * 3);
+  border: var(--sub-button-border);
+  border-radius: var(--button-border-radius);
+  padding: var(--button-border-radius);
+  box-sizing: border-box;
+  font-size: calc(var(--responsive-font-size) * 1);
+}
+
+.local-battle-guest__battle-start {
+  grid-area: battle-start;
+  align-self: start;
+  font-size: calc(var(--responsive-font-size) * 1);
+  color: var(--button-font-color);
+  background-color: var(--sub-button-background-color);
+  border-radius: var(--button-border-radius);
+  border: var(--sub-button-border);
+  height: calc(var(--responsive-font-size) * 3);
+  min-width: calc(var(--responsive-font-size) * 10);
 }

--- a/src/css/local-battle-guest.css
+++ b/src/css/local-battle-guest.css
@@ -35,9 +35,8 @@
       100vw - var(--safe-area-right) - var(--safe-area-left) -
         var(--closer-width) * 0.5
     ),
-    80vw
+    60vw
   );
-  min-height: 60vh;
   transform: translate(-50%, -50%);
   color: var(--font-color);
   background-color: var(--background-color);
@@ -49,10 +48,8 @@
   padding: max(var(--dialog-padding), calc(var(--closer-height) / 2))
     var(--dialog-padding) var(--dialog-padding) var(--dialog-padding);
   font-size: calc(var(--responsive-font-size) * 1.2);
-  display: grid;
-  grid-template:
-    "description description" auto
-    "password battle-start" auto / 1fr auto;
+  display: flex;
+  flex-direction: column;
   gap: calc(var(--responsive-font-size) * 0.5);
 }
 
@@ -65,15 +62,12 @@
 }
 
 .local-battle-guest__description {
-  grid-area: description;
-  align-self: end;
-  font-size: calc(var(--responsive-font-size) * 2);
-  margin-bottom: calc(var(--responsive-font-size) * 2);
+  text-align: center;
+  font-size: calc(var(--responsive-font-size) * 1.6);
+  margin-bottom: calc(var(--responsive-font-size) * 0.5);
 }
 
 .local-battle-guest__password {
-  grid-area: password;
-  align-self: start;
   height: calc(var(--responsive-font-size) * 3);
   border: var(--sub-button-border);
   border-radius: var(--button-border-radius);
@@ -83,13 +77,11 @@
 }
 
 .local-battle-guest__battle-start {
-  grid-area: battle-start;
-  align-self: start;
   font-size: calc(var(--responsive-font-size) * 1);
   color: var(--button-font-color);
-  background-color: var(--sub-button-background-color);
+  background-color: var(--button-background-color);
   border-radius: var(--button-border-radius);
-  border: var(--sub-button-border);
+  border: var(--button-border);
   height: calc(var(--responsive-font-size) * 3);
   min-width: calc(var(--responsive-font-size) * 10);
 }

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -42,3 +42,4 @@
 @import url("status.css");
 @import url("local-battle-selector.css");
 @import url("local-battle-host.css");
+@import url("local-battle-guest.css");

--- a/src/js/dom-dialogs/local-battle-guest/dom/class-name.ts
+++ b/src/js/dom-dialogs/local-battle-guest/dom/class-name.ts
@@ -1,0 +1,2 @@
+/** ルートHTML要素のクラス名 */
+export const ROOT_CLASS="local-battle-guest-dialog";

--- a/src/js/dom-dialogs/local-battle-guest/dom/class-name.ts
+++ b/src/js/dom-dialogs/local-battle-guest/dom/class-name.ts
@@ -1,2 +1,2 @@
 /** ルートHTML要素のクラス名 */
-export const ROOT_CLASS="local-battle-guest-dialog";
+export const ROOT_CLASS = "local-battle-guest";

--- a/src/js/dom-dialogs/local-battle-guest/dom/extract-element.ts
+++ b/src/js/dom-dialogs/local-battle-guest/dom/extract-element.ts
@@ -1,4 +1,12 @@
 /**
+ * バックグラウンドを抽出する
+ * @param root ルートHTML要素
+ * @returns 抽出したもの
+ */
+export const extractBackGround = (root: HTMLElement): HTMLElement =>
+  root.querySelector(`[data-id="background"]`) ?? document.createElement("div");
+
+/**
  * クロージャーを抽出する
  * @param root ルートHTML要素
  * @returns 抽出したもの

--- a/src/js/dom-dialogs/local-battle-guest/dom/extract-element.ts
+++ b/src/js/dom-dialogs/local-battle-guest/dom/extract-element.ts
@@ -1,0 +1,28 @@
+/**
+ * クロージャーを抽出する
+ * @param root ルートHTML要素
+ * @returns 抽出したもの
+ */
+export const extractCloser = (root: HTMLElement): HTMLElement =>
+  root.querySelector(`[data-id="closer"]`) ?? document.createElement("div");
+
+/**
+ * あいことばを抽出する
+ * @param root ルートHTML要素
+ * @returns 抽出したもの
+ */
+export const extractPassword = (root: HTMLElement): HTMLInputElement => {
+  const found = root.querySelector(`[data-id="password"]`);
+  return found instanceof HTMLInputElement
+    ? found
+    : document.createElement("input");
+};
+
+/**
+ * バトルスタートボタンを抽出する
+ * @param root ルートHTML要素
+ * @returns 抽出したもの
+ */
+export const extractBattleStart = (root: HTMLElement): HTMLElement =>
+  root.querySelector(`[data-id="battle-start"]`) ??
+  document.createElement("div");

--- a/src/js/dom-dialogs/local-battle-guest/dom/root-inner-html.hbs
+++ b/src/js/dom-dialogs/local-battle-guest/dom/root-inner-html.hbs
@@ -6,7 +6,7 @@
     src="{{closerPath}}"
     data-id="closer"
   />
-  <div class="{{ROOT_CLASS}}__description">あいことばを入れてね</div>
+  <div class="{{ROOT_CLASS}}__description">あいことばを入れてね。</div>
   <input class="{{ROOT_CLASS}}__password" type="text" data-id="password" />
   <button
     class="{{ROOT_CLASS}}__battle-start"

--- a/src/js/dom-dialogs/local-battle-guest/dom/root-inner-html.hbs
+++ b/src/js/dom-dialogs/local-battle-guest/dom/root-inner-html.hbs
@@ -1,0 +1,1 @@
+local battle guest dialog

--- a/src/js/dom-dialogs/local-battle-guest/dom/root-inner-html.hbs
+++ b/src/js/dom-dialogs/local-battle-guest/dom/root-inner-html.hbs
@@ -1,1 +1,9 @@
-local battle guest dialog
+<div class="{{ROOT_CLASS}}__background" data-id="background"></div>
+<div class="{{ROOT_CLASS}}__dialog">
+  <img
+    class="{{ROOT_CLASS}}__closer"
+    alt="閉じる"
+    src="{{closerPath}}"
+    data-id="closer"
+  />
+</div>

--- a/src/js/dom-dialogs/local-battle-guest/dom/root-inner-html.hbs
+++ b/src/js/dom-dialogs/local-battle-guest/dom/root-inner-html.hbs
@@ -6,4 +6,10 @@
     src="{{closerPath}}"
     data-id="closer"
   />
+  <div class="{{ROOT_CLASS}}__description">あいことばを入れてね</div>
+  <input class="{{ROOT_CLASS}}__password" type="text" data-id="password" />
+  <button
+    class="{{ROOT_CLASS}}__battle-start"
+    data-id="battle-start"
+  >バトルスタート</button>
 </div>

--- a/src/js/dom-dialogs/local-battle-guest/dom/root-inner-html.ts
+++ b/src/js/dom-dialogs/local-battle-guest/dom/root-inner-html.ts
@@ -1,9 +1,21 @@
+import { ResourcesContainer } from "../../../resource";
+import { PathIds } from "../../../resource/path/ids";
+import { ROOT_CLASS } from "./class-name";
 import template from "./root-inner-html.hbs";
+
+/** ルートHTML要素のinnerHTMLのオプション */
+export type RootInnerHTMLOptions = ResourcesContainer;
 
 /**
  * ルートHTML要素のinnerHTMLを生成する
  * @returns 生成したinnerHTML
  */
-export const rootInnerHTML = () => {
-  return template({});
+export const rootInnerHTML = (options: RootInnerHTMLOptions) => {
+  const { resources } = options;
+  const closerPath =
+    resources.paths.find((p) => p.id === PathIds.CLOSER)?.path ?? "";
+  return template({
+    ROOT_CLASS,
+    closerPath,
+  });
 };

--- a/src/js/dom-dialogs/local-battle-guest/dom/root-inner-html.ts
+++ b/src/js/dom-dialogs/local-battle-guest/dom/root-inner-html.ts
@@ -1,0 +1,9 @@
+import template from "./root-inner-html.hbs";
+
+/**
+ * ルートHTML要素のinnerHTMLを生成する
+ * @returns 生成したinnerHTML
+ */
+export const rootInnerHTML = () => {
+  return template({});
+};

--- a/src/js/dom-dialogs/local-battle-guest/index.ts
+++ b/src/js/dom-dialogs/local-battle-guest/index.ts
@@ -1,4 +1,7 @@
+import { Unsubscribable } from "rxjs";
+
 import { DOMDialog } from "../dialog";
+import { bindEventListeners } from "./procedure/bind-event-listeners";
 import {
   createLocalBattleGuestDialogProps,
   CreateLocalBattleGuestDialogPropsOptions,
@@ -13,6 +16,8 @@ export type LocalBattleGuestDialogOptions =
 export class LocalBattleGuestDialog implements DOMDialog {
   /** プロパティ */
   #props: LocalBattleGuestDialogProps;
+  /** アンサブスクライバ */
+  #unsubscribers: Unsubscribable[];
 
   /**
    * コンストラクタ
@@ -20,11 +25,14 @@ export class LocalBattleGuestDialog implements DOMDialog {
    */
   constructor(options: LocalBattleGuestDialogOptions) {
     this.#props = createLocalBattleGuestDialogProps(options);
+    this.#unsubscribers = bindEventListeners(this.#props);
   }
 
   /** @override */
   destructor(): void {
-    // NOP
+    this.#unsubscribers.forEach((u) => {
+      u.unsubscribe();
+    });
   }
 
   /** @override */

--- a/src/js/dom-dialogs/local-battle-guest/index.ts
+++ b/src/js/dom-dialogs/local-battle-guest/index.ts
@@ -1,6 +1,13 @@
 import { DOMDialog } from "../dialog";
-import { createLocalBattleGuestDialogProps } from "./procedure/create-local-battle-guest-dialog-props";
+import {
+  createLocalBattleGuestDialogProps,
+  CreateLocalBattleGuestDialogPropsOptions,
+} from "./procedure/create-local-battle-guest-dialog-props";
 import { LocalBattleGuestDialogProps } from "./props";
+
+/** ローカル対戦ゲストのダイアログのオプション */
+export type LocalBattleGuestDialogOptions =
+  CreateLocalBattleGuestDialogPropsOptions;
 
 /** ローカル対戦ゲストのダイアログ */
 export class LocalBattleGuestDialog implements DOMDialog {
@@ -9,9 +16,10 @@ export class LocalBattleGuestDialog implements DOMDialog {
 
   /**
    * コンストラクタ
+   * @param options オプション
    */
-  constructor() {
-    this.#props = createLocalBattleGuestDialogProps();
+  constructor(options: LocalBattleGuestDialogOptions) {
+    this.#props = createLocalBattleGuestDialogProps(options);
   }
 
   /** @override */

--- a/src/js/dom-dialogs/local-battle-guest/index.ts
+++ b/src/js/dom-dialogs/local-battle-guest/index.ts
@@ -1,0 +1,26 @@
+import { DOMDialog } from "../dialog";
+import { createLocalBattleGuestDialogProps } from "./procedure/create-local-battle-guest-dialog-props";
+import { LocalBattleGuestDialogProps } from "./props";
+
+/** ローカル対戦ゲストのダイアログ */
+export class LocalBattleGuestDialog implements DOMDialog {
+  /** プロパティ */
+  #props: LocalBattleGuestDialogProps;
+
+  /**
+   * コンストラクタ
+   */
+  constructor() {
+    this.#props = createLocalBattleGuestDialogProps();
+  }
+
+  /** @override */
+  destructor(): void {
+    // NOP
+  }
+
+  /** @override */
+  getRootHTMLElement(): HTMLElement {
+    return this.#props.root;
+  }
+}

--- a/src/js/dom-dialogs/local-battle-guest/index.ts
+++ b/src/js/dom-dialogs/local-battle-guest/index.ts
@@ -1,4 +1,4 @@
-import { Unsubscribable } from "rxjs";
+import { Observable, Unsubscribable } from "rxjs";
 
 import { DOMDialog } from "../dialog";
 import { bindEventListeners } from "./procedure/bind-event-listeners";
@@ -6,7 +6,7 @@ import {
   createLocalBattleGuestDialogProps,
   CreateLocalBattleGuestDialogPropsOptions,
 } from "./procedure/create-local-battle-guest-dialog-props";
-import { LocalBattleGuestDialogProps } from "./props";
+import { BattleStartPayload, LocalBattleGuestDialogProps } from "./props";
 
 /** ローカル対戦ゲストのダイアログのオプション */
 export type LocalBattleGuestDialogOptions =
@@ -38,5 +38,13 @@ export class LocalBattleGuestDialog implements DOMDialog {
   /** @override */
   getRootHTMLElement(): HTMLElement {
     return this.#props.root;
+  }
+
+  /**
+   * バトルスタートを通知する
+   * @returns バトルスタート通知ストリーム
+   */
+  notifyBattleStart(): Observable<BattleStartPayload> {
+    return this.#props.battleStartSubject;
   }
 }

--- a/src/js/dom-dialogs/local-battle-guest/index.ts
+++ b/src/js/dom-dialogs/local-battle-guest/index.ts
@@ -42,9 +42,17 @@ export class LocalBattleGuestDialog implements DOMDialog {
 
   /**
    * バトルスタートを通知する
-   * @returns バトルスタート通知ストリーム
+   * @returns 通知ストリーム
    */
   notifyBattleStart(): Observable<BattleStartPayload> {
     return this.#props.battleStartSubject;
+  }
+
+  /**
+   * ダイアログが閉じられたことを通知する
+   * @returns 通知ストリーム
+   */
+  notifyDialogClosed(): Observable<void> {
+    return this.#props.dialogClosedSubject;
   }
 }

--- a/src/js/dom-dialogs/local-battle-guest/procedure/bind-event-listeners.ts
+++ b/src/js/dom-dialogs/local-battle-guest/procedure/bind-event-listeners.ts
@@ -3,6 +3,7 @@ import { Unsubscribable } from "rxjs";
 import { domPushStream } from "../../../dom/push-dom";
 import { LocalBattleGuestDialogProps } from "../props";
 import { onBattleStartPushed } from "./on-battle-start-pushed";
+import { onCloserPushed } from "./on-closer-pushed";
 
 /**
  * イベントリスナーをバインドする
@@ -15,6 +16,9 @@ export const bindEventListeners = (
   return [
     domPushStream(props.battleStartButton).subscribe((action) => {
       onBattleStartPushed(props, action);
+    }),
+    domPushStream(props.closer).subscribe((action) => {
+      onCloserPushed(props, action);
     }),
   ];
 };

--- a/src/js/dom-dialogs/local-battle-guest/procedure/bind-event-listeners.ts
+++ b/src/js/dom-dialogs/local-battle-guest/procedure/bind-event-listeners.ts
@@ -2,6 +2,7 @@ import { Unsubscribable } from "rxjs";
 
 import { domPushStream } from "../../../dom/push-dom";
 import { LocalBattleGuestDialogProps } from "../props";
+import { onBackGroundPushed } from "./on-back-ground-pushed";
 import { onBattleStartPushed } from "./on-battle-start-pushed";
 import { onCloserPushed } from "./on-closer-pushed";
 
@@ -19,6 +20,9 @@ export const bindEventListeners = (
     }),
     domPushStream(props.closer).subscribe((action) => {
       onCloserPushed(props, action);
+    }),
+    domPushStream(props.backGround).subscribe((action) => {
+      onBackGroundPushed(props, action);
     }),
   ];
 };

--- a/src/js/dom-dialogs/local-battle-guest/procedure/bind-event-listeners.ts
+++ b/src/js/dom-dialogs/local-battle-guest/procedure/bind-event-listeners.ts
@@ -1,0 +1,20 @@
+import { Unsubscribable } from "rxjs";
+
+import { domPushStream } from "../../../dom/push-dom";
+import { LocalBattleGuestDialogProps } from "../props";
+import { onBattleStartPushed } from "./on-battle-start-pushed";
+
+/**
+ * イベントリスナーをバインドする
+ * @param props プロパティ
+ * @returns アンサブスクライバ
+ */
+export const bindEventListeners = (
+  props: LocalBattleGuestDialogProps,
+): Unsubscribable[] => {
+  return [
+    domPushStream(props.battleStartButton).subscribe((action) => {
+      onBattleStartPushed(props, action);
+    }),
+  ];
+};

--- a/src/js/dom-dialogs/local-battle-guest/procedure/create-local-battle-guest-dialog-props.ts
+++ b/src/js/dom-dialogs/local-battle-guest/procedure/create-local-battle-guest-dialog-props.ts
@@ -1,4 +1,6 @@
+import { Exclusive } from "../../../exclusive/exclusive";
 import { ROOT_CLASS } from "../dom/class-name";
+import { extractBattleStart } from "../dom/extract-element";
 import { rootInnerHTML, RootInnerHTMLOptions } from "../dom/root-inner-html";
 import { LocalBattleGuestDialogProps } from "../props";
 
@@ -16,5 +18,9 @@ export const createLocalBattleGuestDialogProps = (
   root.className = ROOT_CLASS;
   root.innerHTML = rootInnerHTML(options);
 
-  return { root };
+  const battleStartButton = extractBattleStart(root);
+
+  const exclusive = new Exclusive();
+
+  return { root, battleStartButton, exclusive };
 };

--- a/src/js/dom-dialogs/local-battle-guest/procedure/create-local-battle-guest-dialog-props.ts
+++ b/src/js/dom-dialogs/local-battle-guest/procedure/create-local-battle-guest-dialog-props.ts
@@ -1,3 +1,5 @@
+import { Subject } from "rxjs";
+
 import { Exclusive } from "../../../exclusive/exclusive";
 import { createEmptySoundResource } from "../../../resource/sound/empty-sound-resource";
 import { SOUND_IDS } from "../../../resource/sound/ids";
@@ -5,7 +7,7 @@ import { SEPlayerContainer } from "../../../se/se-player";
 import { ROOT_CLASS } from "../dom/class-name";
 import { extractBattleStart } from "../dom/extract-element";
 import { rootInnerHTML, RootInnerHTMLOptions } from "../dom/root-inner-html";
-import { LocalBattleGuestDialogProps } from "../props";
+import { BattleStartPayload, LocalBattleGuestDialogProps } from "../props";
 
 /** ダイアログのプロパティを生成するオプション */
 export type CreateLocalBattleGuestDialogPropsOptions = RootInnerHTMLOptions &
@@ -30,6 +32,9 @@ export const createLocalBattleGuestDialogProps = (
     resources.sounds.find((s) => s.id === SOUND_IDS.PUSH_BUTTON) ??
     createEmptySoundResource();
 
+  
+  const battleStartSubject = new Subject<BattleStartPayload>();
+
   const exclusive = new Exclusive();
 
   return {
@@ -38,6 +43,8 @@ export const createLocalBattleGuestDialogProps = (
 
     se,
     battleStartSound,
+
+    battleStartSubject,
 
     exclusive,
   };

--- a/src/js/dom-dialogs/local-battle-guest/procedure/create-local-battle-guest-dialog-props.ts
+++ b/src/js/dom-dialogs/local-battle-guest/procedure/create-local-battle-guest-dialog-props.ts
@@ -1,11 +1,15 @@
 import { Exclusive } from "../../../exclusive/exclusive";
+import { createEmptySoundResource } from "../../../resource/sound/empty-sound-resource";
+import { SOUND_IDS } from "../../../resource/sound/ids";
+import { SEPlayerContainer } from "../../../se/se-player";
 import { ROOT_CLASS } from "../dom/class-name";
 import { extractBattleStart } from "../dom/extract-element";
 import { rootInnerHTML, RootInnerHTMLOptions } from "../dom/root-inner-html";
 import { LocalBattleGuestDialogProps } from "../props";
 
 /** ダイアログのプロパティを生成するオプション */
-export type CreateLocalBattleGuestDialogPropsOptions = RootInnerHTMLOptions;
+export type CreateLocalBattleGuestDialogPropsOptions = RootInnerHTMLOptions &
+  SEPlayerContainer;
 
 /**
  * ダイアログのプロパティを生成する
@@ -14,13 +18,27 @@ export type CreateLocalBattleGuestDialogPropsOptions = RootInnerHTMLOptions;
 export const createLocalBattleGuestDialogProps = (
   options: CreateLocalBattleGuestDialogPropsOptions,
 ): LocalBattleGuestDialogProps => {
+  const { se, resources } = options;
+
   const root = document.createElement("div");
   root.className = ROOT_CLASS;
   root.innerHTML = rootInnerHTML(options);
 
   const battleStartButton = extractBattleStart(root);
 
+  const battleStartSound =
+    resources.sounds.find((s) => s.id === SOUND_IDS.PUSH_BUTTON) ??
+    createEmptySoundResource();
+
   const exclusive = new Exclusive();
 
-  return { root, battleStartButton, exclusive };
+  return {
+    root,
+    battleStartButton,
+
+    se,
+    battleStartSound,
+
+    exclusive,
+  };
 };

--- a/src/js/dom-dialogs/local-battle-guest/procedure/create-local-battle-guest-dialog-props.ts
+++ b/src/js/dom-dialogs/local-battle-guest/procedure/create-local-battle-guest-dialog-props.ts
@@ -5,7 +5,7 @@ import { createEmptySoundResource } from "../../../resource/sound/empty-sound-re
 import { SOUND_IDS } from "../../../resource/sound/ids";
 import { SEPlayerContainer } from "../../../se/se-player";
 import { ROOT_CLASS } from "../dom/class-name";
-import { extractBattleStart, extractPassword } from "../dom/extract-element";
+import { extractBattleStart, extractCloser, extractPassword } from "../dom/extract-element";
 import { rootInnerHTML, RootInnerHTMLOptions } from "../dom/root-inner-html";
 import { BattleStartPayload, LocalBattleGuestDialogProps } from "../props";
 
@@ -26,6 +26,8 @@ export const createLocalBattleGuestDialogProps = (
   root.className = ROOT_CLASS;
   root.innerHTML = rootInnerHTML(options);
 
+  const closer = extractCloser(root);
+
   const password = extractPassword(root);
 
   const battleStartButton = extractBattleStart(root);
@@ -40,6 +42,7 @@ export const createLocalBattleGuestDialogProps = (
 
   return {
     root,
+    closer,
     password,
     battleStartButton,
 

--- a/src/js/dom-dialogs/local-battle-guest/procedure/create-local-battle-guest-dialog-props.ts
+++ b/src/js/dom-dialogs/local-battle-guest/procedure/create-local-battle-guest-dialog-props.ts
@@ -6,6 +6,7 @@ import { SOUND_IDS } from "../../../resource/sound/ids";
 import { SEPlayerContainer } from "../../../se/se-player";
 import { ROOT_CLASS } from "../dom/class-name";
 import {
+  extractBackGround,
   extractBattleStart,
   extractCloser,
   extractPassword,
@@ -30,6 +31,8 @@ export const createLocalBattleGuestDialogProps = (
   root.className = ROOT_CLASS;
   root.innerHTML = rootInnerHTML(options);
 
+  const backGround = extractBackGround(root);
+
   const closer = extractCloser(root);
 
   const password = extractPassword(root);
@@ -50,6 +53,7 @@ export const createLocalBattleGuestDialogProps = (
 
   return {
     root,
+    backGround,
     closer,
     password,
     battleStartButton,

--- a/src/js/dom-dialogs/local-battle-guest/procedure/create-local-battle-guest-dialog-props.ts
+++ b/src/js/dom-dialogs/local-battle-guest/procedure/create-local-battle-guest-dialog-props.ts
@@ -5,7 +5,11 @@ import { createEmptySoundResource } from "../../../resource/sound/empty-sound-re
 import { SOUND_IDS } from "../../../resource/sound/ids";
 import { SEPlayerContainer } from "../../../se/se-player";
 import { ROOT_CLASS } from "../dom/class-name";
-import { extractBattleStart, extractCloser, extractPassword } from "../dom/extract-element";
+import {
+  extractBattleStart,
+  extractCloser,
+  extractPassword,
+} from "../dom/extract-element";
 import { rootInnerHTML, RootInnerHTMLOptions } from "../dom/root-inner-html";
 import { BattleStartPayload, LocalBattleGuestDialogProps } from "../props";
 
@@ -35,8 +39,12 @@ export const createLocalBattleGuestDialogProps = (
   const battleStartSound =
     resources.sounds.find((s) => s.id === SOUND_IDS.PUSH_BUTTON) ??
     createEmptySoundResource();
+  const dialogClosedSound =
+    resources.sounds.find((s) => s.id === SOUND_IDS.CHANGE_VALUE) ??
+    createEmptySoundResource();
 
   const battleStartSubject = new Subject<BattleStartPayload>();
+  const dialogClosedSubject = new Subject<void>();
 
   const exclusive = new Exclusive();
 
@@ -48,8 +56,10 @@ export const createLocalBattleGuestDialogProps = (
 
     se,
     battleStartSound,
+    dialogClosedSound,
 
     battleStartSubject,
+    dialogClosedSubject,
 
     exclusive,
   };

--- a/src/js/dom-dialogs/local-battle-guest/procedure/create-local-battle-guest-dialog-props.ts
+++ b/src/js/dom-dialogs/local-battle-guest/procedure/create-local-battle-guest-dialog-props.ts
@@ -5,7 +5,7 @@ import { createEmptySoundResource } from "../../../resource/sound/empty-sound-re
 import { SOUND_IDS } from "../../../resource/sound/ids";
 import { SEPlayerContainer } from "../../../se/se-player";
 import { ROOT_CLASS } from "../dom/class-name";
-import { extractBattleStart } from "../dom/extract-element";
+import { extractBattleStart, extractPassword } from "../dom/extract-element";
 import { rootInnerHTML, RootInnerHTMLOptions } from "../dom/root-inner-html";
 import { BattleStartPayload, LocalBattleGuestDialogProps } from "../props";
 
@@ -26,19 +26,21 @@ export const createLocalBattleGuestDialogProps = (
   root.className = ROOT_CLASS;
   root.innerHTML = rootInnerHTML(options);
 
+  const password = extractPassword(root);
+
   const battleStartButton = extractBattleStart(root);
 
   const battleStartSound =
     resources.sounds.find((s) => s.id === SOUND_IDS.PUSH_BUTTON) ??
     createEmptySoundResource();
 
-  
   const battleStartSubject = new Subject<BattleStartPayload>();
 
   const exclusive = new Exclusive();
 
   return {
     root,
+    password,
     battleStartButton,
 
     se,

--- a/src/js/dom-dialogs/local-battle-guest/procedure/create-local-battle-guest-dialog-props.ts
+++ b/src/js/dom-dialogs/local-battle-guest/procedure/create-local-battle-guest-dialog-props.ts
@@ -1,0 +1,16 @@
+import { ROOT_CLASS } from "../dom/class-name";
+import { rootInnerHTML } from "../dom/root-inner-html";
+import { LocalBattleGuestDialogProps } from "../props";
+
+/**
+ * ダイアログのプロパティを生成する
+ * @returns 生成したプロパティ
+ */
+export const createLocalBattleGuestDialogProps =
+  (): LocalBattleGuestDialogProps => {
+    const root = document.createElement("div");
+    root.className = ROOT_CLASS;
+    root.innerHTML = rootInnerHTML();
+
+    return { root };
+  };

--- a/src/js/dom-dialogs/local-battle-guest/procedure/create-local-battle-guest-dialog-props.ts
+++ b/src/js/dom-dialogs/local-battle-guest/procedure/create-local-battle-guest-dialog-props.ts
@@ -1,16 +1,20 @@
 import { ROOT_CLASS } from "../dom/class-name";
-import { rootInnerHTML } from "../dom/root-inner-html";
+import { rootInnerHTML, RootInnerHTMLOptions } from "../dom/root-inner-html";
 import { LocalBattleGuestDialogProps } from "../props";
+
+/** ダイアログのプロパティを生成するオプション */
+export type CreateLocalBattleGuestDialogPropsOptions = RootInnerHTMLOptions;
 
 /**
  * ダイアログのプロパティを生成する
  * @returns 生成したプロパティ
  */
-export const createLocalBattleGuestDialogProps =
-  (): LocalBattleGuestDialogProps => {
-    const root = document.createElement("div");
-    root.className = ROOT_CLASS;
-    root.innerHTML = rootInnerHTML();
+export const createLocalBattleGuestDialogProps = (
+  options: CreateLocalBattleGuestDialogPropsOptions,
+): LocalBattleGuestDialogProps => {
+  const root = document.createElement("div");
+  root.className = ROOT_CLASS;
+  root.innerHTML = rootInnerHTML(options);
 
-    return { root };
-  };
+  return { root };
+};

--- a/src/js/dom-dialogs/local-battle-guest/procedure/on-back-ground-pushed.ts
+++ b/src/js/dom-dialogs/local-battle-guest/procedure/on-back-ground-pushed.ts
@@ -1,0 +1,19 @@
+import { PushDOM } from "../../../dom/push-dom";
+import { LocalBattleGuestDialogProps } from "../props";
+
+/**
+ * バックグラウンドを押したときの処理
+ * @param props プロパティ
+ * @param action アクション
+ */
+export const onBackGroundPushed = (
+  props: LocalBattleGuestDialogProps,
+  action: PushDOM,
+) => {
+  action.event.preventDefault();
+  action.event.stopPropagation();
+  props.exclusive.execute(async () => {
+    props.se.play(props.dialogClosedSound);
+    props.dialogClosedSubject.next();
+  });
+};

--- a/src/js/dom-dialogs/local-battle-guest/procedure/on-battle-start-pushed.ts
+++ b/src/js/dom-dialogs/local-battle-guest/procedure/on-battle-start-pushed.ts
@@ -14,6 +14,7 @@ export const onBattleStartPushed = (
   action.event.preventDefault();
   action.event.stopPropagation();
   props.exclusive.execute(async () => {
+    props.se.play(props.battleStartSound);
     await pop(props.battleStartButton);
   });
 };

--- a/src/js/dom-dialogs/local-battle-guest/procedure/on-battle-start-pushed.ts
+++ b/src/js/dom-dialogs/local-battle-guest/procedure/on-battle-start-pushed.ts
@@ -16,5 +16,7 @@ export const onBattleStartPushed = (
   props.exclusive.execute(async () => {
     props.se.play(props.battleStartSound);
     await pop(props.battleStartButton);
+    const password = props.password.value;
+    props.battleStartSubject.next({ password });
   });
 };

--- a/src/js/dom-dialogs/local-battle-guest/procedure/on-battle-start-pushed.ts
+++ b/src/js/dom-dialogs/local-battle-guest/procedure/on-battle-start-pushed.ts
@@ -1,0 +1,19 @@
+import { pop } from "../../../dom/pop";
+import { PushDOM } from "../../../dom/push-dom";
+import { LocalBattleGuestDialogProps } from "../props";
+
+/**
+ * バトルスタートが押されたときの処理
+ * @param props プロパティ
+ * @param action アクション
+ */
+export const onBattleStartPushed = (
+  props: LocalBattleGuestDialogProps,
+  action: PushDOM,
+) => {
+  action.event.preventDefault();
+  action.event.stopPropagation();
+  props.exclusive.execute(async () => {
+    await pop(props.battleStartButton);
+  });
+};

--- a/src/js/dom-dialogs/local-battle-guest/procedure/on-closer-pushed.ts
+++ b/src/js/dom-dialogs/local-battle-guest/procedure/on-closer-pushed.ts
@@ -1,0 +1,19 @@
+import { pop } from "../../../dom/pop";
+import { PushDOM } from "../../../dom/push-dom";
+import { LocalBattleGuestDialogProps } from "../props";
+
+/**
+ * クロージャーを押したときの処理
+ * @param props プロパティ
+ * @param action アクション
+ */
+export const onCloserPushed = (
+  props: LocalBattleGuestDialogProps,
+  action: PushDOM,
+): void => {
+  action.event.preventDefault();
+  action.event.stopPropagation();
+  props.exclusive.execute(async () => {
+    await pop(props.closer, 1.3);
+  });
+};

--- a/src/js/dom-dialogs/local-battle-guest/procedure/on-closer-pushed.ts
+++ b/src/js/dom-dialogs/local-battle-guest/procedure/on-closer-pushed.ts
@@ -14,6 +14,8 @@ export const onCloserPushed = (
   action.event.preventDefault();
   action.event.stopPropagation();
   props.exclusive.execute(async () => {
+    props.se.play(props.dialogClosedSound);
     await pop(props.closer, 1.3);
+    props.dialogClosedSubject.next();
   });
 };

--- a/src/js/dom-dialogs/local-battle-guest/props.ts
+++ b/src/js/dom-dialogs/local-battle-guest/props.ts
@@ -1,0 +1,5 @@
+/** ローカル対戦ゲストダイアログのプロパティ */
+export type LocalBattleGuestDialogProps = {
+  /** ルートHTML要素 */
+  root: HTMLElement;
+};

--- a/src/js/dom-dialogs/local-battle-guest/props.ts
+++ b/src/js/dom-dialogs/local-battle-guest/props.ts
@@ -23,9 +23,13 @@ export type LocalBattleGuestDialogProps = SEPlayerContainer & {
 
   /** バトルスタートボタンを押したときのサウンド */
   battleStartSound: SoundResource;
+  /** ダイアログを閉じたときのサウンド */
+  dialogClosedSound: SoundResource;
 
   /** バトルスタート通知 */
   battleStartSubject: Subject<BattleStartPayload>;
+  /** ダイアログが閉じられたときの通知 */
+  dialogClosedSubject: Subject<void>;
 
   /** 排他制御 */
   exclusive: Exclusive;

--- a/src/js/dom-dialogs/local-battle-guest/props.ts
+++ b/src/js/dom-dialogs/local-battle-guest/props.ts
@@ -1,9 +1,17 @@
+import { Subject } from "rxjs";
+
 import { Exclusive } from "../../exclusive/exclusive";
 import { SoundResource } from "../../resource/sound/resource";
 import { SEPlayerContainer } from "../../se/se-player";
 
+/** バトルスタート通知のペイロード */
+export type BattleStartPayload = {
+  /** 入力したパスワード */
+  password: string;
+};
+
 /** ローカル対戦ゲストダイアログのプロパティ */
-export type LocalBattleGuestDialogProps = SEPlayerContainer &{
+export type LocalBattleGuestDialogProps = SEPlayerContainer & {
   /** ルートHTML要素 */
   root: HTMLElement;
   /** バトルスタートボタン */
@@ -11,6 +19,9 @@ export type LocalBattleGuestDialogProps = SEPlayerContainer &{
 
   /** バトルスタートボタンを押したときのサウンド */
   battleStartSound: SoundResource;
+
+  /** バトルスタート通知 */
+  battleStartSubject: Subject<BattleStartPayload>;
 
   /** 排他制御 */
   exclusive: Exclusive;

--- a/src/js/dom-dialogs/local-battle-guest/props.ts
+++ b/src/js/dom-dialogs/local-battle-guest/props.ts
@@ -1,5 +1,12 @@
+import { Exclusive } from "../../exclusive/exclusive";
+
 /** ローカル対戦ゲストダイアログのプロパティ */
 export type LocalBattleGuestDialogProps = {
   /** ルートHTML要素 */
   root: HTMLElement;
+  /** バトルスタートボタン */
+  battleStartButton: HTMLElement;
+
+  /** 排他制御 */
+  exclusive: Exclusive;
 };

--- a/src/js/dom-dialogs/local-battle-guest/props.ts
+++ b/src/js/dom-dialogs/local-battle-guest/props.ts
@@ -14,6 +14,8 @@ export type BattleStartPayload = {
 export type LocalBattleGuestDialogProps = SEPlayerContainer & {
   /** ルートHTML要素 */
   root: HTMLElement;
+  /** クロージャー */
+  closer: HTMLElement;
   /** あいことば入力欄 */
   password: HTMLInputElement;
   /** バトルスタートボタン */

--- a/src/js/dom-dialogs/local-battle-guest/props.ts
+++ b/src/js/dom-dialogs/local-battle-guest/props.ts
@@ -14,6 +14,8 @@ export type BattleStartPayload = {
 export type LocalBattleGuestDialogProps = SEPlayerContainer & {
   /** ルートHTML要素 */
   root: HTMLElement;
+  /** あいことば入力欄 */
+  password: HTMLInputElement;
   /** バトルスタートボタン */
   battleStartButton: HTMLElement;
 

--- a/src/js/dom-dialogs/local-battle-guest/props.ts
+++ b/src/js/dom-dialogs/local-battle-guest/props.ts
@@ -1,11 +1,16 @@
 import { Exclusive } from "../../exclusive/exclusive";
+import { SoundResource } from "../../resource/sound/resource";
+import { SEPlayerContainer } from "../../se/se-player";
 
 /** ローカル対戦ゲストダイアログのプロパティ */
-export type LocalBattleGuestDialogProps = {
+export type LocalBattleGuestDialogProps = SEPlayerContainer &{
   /** ルートHTML要素 */
   root: HTMLElement;
   /** バトルスタートボタン */
   battleStartButton: HTMLElement;
+
+  /** バトルスタートボタンを押したときのサウンド */
+  battleStartSound: SoundResource;
 
   /** 排他制御 */
   exclusive: Exclusive;

--- a/src/js/dom-dialogs/local-battle-guest/props.ts
+++ b/src/js/dom-dialogs/local-battle-guest/props.ts
@@ -14,6 +14,8 @@ export type BattleStartPayload = {
 export type LocalBattleGuestDialogProps = SEPlayerContainer & {
   /** ルートHTML要素 */
   root: HTMLElement;
+  /** バックグラウンド */
+  backGround: HTMLElement;
   /** クロージャー */
   closer: HTMLElement;
   /** あいことば入力欄 */

--- a/stories/local-battle-guest-dialog.stories.ts
+++ b/stories/local-battle-guest-dialog.stories.ts
@@ -1,0 +1,12 @@
+import { LocalBattleGuestDialog } from "../src/js/dom-dialogs/local-battle-guest";
+import { domStub } from "./stub/dom-stub";
+
+export default {
+  title: "local-battle-guest",
+};
+
+/** ダイアログ表示 */
+export const dialog = domStub(() => {
+  const dialog = new LocalBattleGuestDialog();
+  return dialog.getRootHTMLElement();
+});

--- a/stories/local-battle-guest-dialog.stories.ts
+++ b/stories/local-battle-guest-dialog.stories.ts
@@ -11,5 +11,8 @@ export const dialog = domStub((options) => {
   dialog.notifyBattleStart().subscribe((payload) => {
     console.log(`battle start ${payload.password}`);
   });
+  dialog.notifyDialogClosed().subscribe(() => {
+    console.log("dialog closed");
+  });
   return dialog.getRootHTMLElement();
 });

--- a/stories/local-battle-guest-dialog.stories.ts
+++ b/stories/local-battle-guest-dialog.stories.ts
@@ -6,7 +6,7 @@ export default {
 };
 
 /** ダイアログ表示 */
-export const dialog = domStub(() => {
-  const dialog = new LocalBattleGuestDialog();
+export const dialog = domStub((options) => {
+  const dialog = new LocalBattleGuestDialog(options);
   return dialog.getRootHTMLElement();
 });

--- a/stories/local-battle-guest-dialog.stories.ts
+++ b/stories/local-battle-guest-dialog.stories.ts
@@ -8,5 +8,8 @@ export default {
 /** ダイアログ表示 */
 export const dialog = domStub((options) => {
   const dialog = new LocalBattleGuestDialog(options);
+  dialog.notifyBattleStart().subscribe((payload) => {
+    console.log(`battle start ${payload.password}`);
+  });
   return dialog.getRootHTMLElement();
 });


### PR DESCRIPTION
This pull request introduces a new "Local Battle Guest" dialog component, which allows a user to join a local battle by entering a password. The implementation includes the dialog's structure, styling, event handling, and integration with the rest of the application. The most important changes are grouped below:

**Feature Implementation: Local Battle Guest Dialog**

* Added the `LocalBattleGuestDialog` class, encapsulating the dialog's lifecycle, DOM structure, and notification streams for "battle start" and "dialog closed" events (`index.ts`).
* Defined the dialog's properties and payload types in `props.ts`, including subjects for event notifications and references to DOM elements.
* Implemented the dialog's inner HTML structure using a Handlebars template (`root-inner-html.hbs`) and a TypeScript wrapper for dynamic resource injection (`root-inner-html.ts`). [[1]](diffhunk://#diff-53b98ace8bf0f44d7ad4a677f2954375a1a064949760aec2541838929bb1eb91R1-R15) [[2]](diffhunk://#diff-205ccf5a6c473ddc902fb62966a89174b8b2199c3607bd740352bf57ae39fb9cR1-R21)
* Created CSS for the dialog, including responsive display rules for landscape and portrait orientations (`local-battle-guest.css`), and imported it into the main stylesheet. [[1]](diffhunk://#diff-d63a0e12c948f61be880aaf2add5e368ffb216b06267d1126b47ced7982430d5R1-R87) [[2]](diffhunk://#diff-a5138fcaebe72f01e0725bbe283bd989ef71063d446ea233be99e99a7ff43b36R45)

**Event Handling and Logic**

* Added extraction utilities for accessing dialog sub-elements by data attributes (`extract-element.ts`).
* Implemented event binding for dialog actions (background click, closer click, and battle start), each triggering appropriate sounds, animations, and notification subjects (`bind-event-listeners.ts`, `on-back-ground-pushed.ts`, `on-closer-pushed.ts`, `on-battle-start-pushed.ts`). [[1]](diffhunk://#diff-bba848c13020fe5fe155a8c94d7161e87934ab2fbdd533f8ef26743af77a8621R1-R28) [[2]](diffhunk://#diff-cffc155e5e73e665d272e531a6e8d844674d7e141f8fa6b719fdb79ef24a9b5dR1-R19) [[3]](diffhunk://#diff-3e35277fc28317cb527c58f957b90e38fa45bfcb5a1debbc01f59d62a415af20R1-R21) [[4]](diffhunk://#diff-9eef423242c30f1517e1d6470ada2c62f641f152149cc8cd13032f96523c6877R1-R22)
* Added a factory for constructing dialog properties, including sound resource resolution and exclusive execution control (`create-local-battle-guest-dialog-props.ts`).

**Storybook Integration**

* Added a Storybook story for the new dialog, enabling interactive testing and logging of dialog events (`local-battle-guest-dialog.stories.ts`).

**Supporting Definitions**

* Added a constant for the dialog's root class name (`class-name.ts`).

These changes collectively introduce a new, fully functional dialog for local battle guest entry, complete with styling, event handling, and integration hooks for the broader application.