### PR TITLE
あいことば対戦、と文言変更した

### DIFF
--- a/src/css/local-battle-selector.css
+++ b/src/css/local-battle-selector.css
@@ -86,11 +86,14 @@
 
 .local-battle-selector__local-battle-host,
 .local-battle-selector__local-battle-guest {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
   min-height: calc(var(--responsive-font-size) * 1);
   border-radius: var(--button-border-radius);
   padding: calc(var(--responsive-font-size) * 1)
     calc(var(--responsive-font-size) * 2);
-  text-align: left;
 }
 
 .local-battle-selector__local-battle-host-title,
@@ -100,10 +103,4 @@
   overflow-wrap: anywhere;
   word-break: normal;
   line-break: strict;
-}
-
-.local-battle-selector__local-battle-host-description,
-.local-battle-selector__local-battle-guest-description {
-  color: var(--button-font-color);
-  font-size: calc(var(--responsive-font-size) * 0.6);
 }

--- a/src/css/local-battle-selector.css
+++ b/src/css/local-battle-selector.css
@@ -4,10 +4,8 @@
   .local-battle-selector {
     --host-background-color: #001a06;
     --host-border: 2px solid #00cc30;
-    --host-box-shadow: 0 0 0.5em #00b32a;
     --guest-background-color: #170a1a;
     --guest-border: 2px solid #e666ff;
-    --guest-box-shadow: 0 0 0.5em #cf5ce6;
 
     display: block;
   }
@@ -40,11 +38,10 @@
   width: min(
     calc(
       100vw - var(--safe-area-right) - var(--safe-area-left) -
-        var(--closer-width) * 0.5
+        var(--closer-width)
     ),
-    90vw
+    calc(var(--responsive-font-size) * 40)
   );
-  min-height: 60vh;
   transform: translate(-50%, -50%);
   color: var(--font-color);
   background-color: var(--background-color);
@@ -73,7 +70,6 @@
   color: var(--button-font-color);
   background-color: var(--host-background-color);
   border: var(--host-border);
-  box-shadow: var(--host-box-shadow);
 }
 
 .local-battle-selector__local-battle-guest {
@@ -81,7 +77,6 @@
   color: var(--button-font-color);
   background-color: var(--guest-background-color);
   border: var(--guest-border);
-  box-shadow: var(--guest-box-shadow);
 }
 
 .local-battle-selector__local-battle-host,
@@ -90,15 +85,10 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  min-height: calc(var(--responsive-font-size) * 1);
   border-radius: var(--button-border-radius);
   padding: calc(var(--responsive-font-size) * 1)
     calc(var(--responsive-font-size) * 2);
-}
-
-.local-battle-selector__local-battle-host-icon,
-.local-battle-selector__local-battle-guest-icon {
-  font-size: calc(var(--responsive-font-size) * 1.8);
+  min-height: calc(var(--responsive-font-size) * 10);
 }
 
 .local-battle-selector__local-battle-host-title,

--- a/src/css/local-battle-selector.css
+++ b/src/css/local-battle-selector.css
@@ -96,6 +96,11 @@
     calc(var(--responsive-font-size) * 2);
 }
 
+.local-battle-selector__local-battle-host-icon,
+.local-battle-selector__local-battle-guest-icon {
+  font-size: calc(var(--responsive-font-size) * 1.8);
+}
+
 .local-battle-selector__local-battle-host-title,
 .local-battle-selector__local-battle-guest-title {
   font-size: calc(var(--responsive-font-size) * 1.2);

--- a/src/css/title.css
+++ b/src/css/title.css
@@ -312,8 +312,8 @@
 
 .title__game-menu--online-beta {
   grid-template:
-    "net-battle   story    arcade" 1fr
-    "local-battle tutorial config" 1fr / 1fr 1fr 1fr;
+    "local-battle story    arcade" 1fr
+    "net-battle   tutorial config" 1fr / 1fr 1fr 1fr;
 }
 
 .title__config,

--- a/src/js/dom-dialogs/local-battle-selector/dom/root-inner-html.hbs
+++ b/src/js/dom-dialogs/local-battle-selector/dom/root-inner-html.hbs
@@ -11,9 +11,8 @@
     alt="あいことばを作る"
     data-id="local-battle-host"
   >
-    <div class="{{ROOT_CLASS}}__local-battle-host-icon">✏️</div>
     <div class="{{ROOT_CLASS}}__local-battle-host-title">
-      あいことばを作る
+      ✏️あいことば<wbr />を作る
     </div>
   </button>
   <button
@@ -21,9 +20,8 @@
     alt="あいことばで入る"
     data-id="local-battle-guest"
   >
-    <div class="{{ROOT_CLASS}}__local-battle-guest-icon">🚪</div>
     <div class="{{ROOT_CLASS}}__local-battle-guest-title">
-      あいことばで入る
+      🚪あいことば<wbr />で入る
     </div>
   </button>
 </div>

--- a/src/js/dom-dialogs/local-battle-selector/dom/root-inner-html.hbs
+++ b/src/js/dom-dialogs/local-battle-selector/dom/root-inner-html.hbs
@@ -11,7 +11,7 @@
     alt="あいことばを作る"
     data-id="local-battle-host"
   >
-    <div class="{{ROOT_CLASS}}__host-icon">✏️</div>
+    <div class="{{ROOT_CLASS}}__local-battle-host-icon">✏️</div>
     <div class="{{ROOT_CLASS}}__local-battle-host-title">
       あいことばを作る
     </div>
@@ -21,7 +21,7 @@
     alt="あいことばで入る"
     data-id="local-battle-guest"
   >
-    <div class="{{ROOT_CLASS}}__guest-icon">🚪</div>
+    <div class="{{ROOT_CLASS}}__local-battle-guest-icon">🚪</div>
     <div class="{{ROOT_CLASS}}__local-battle-guest-title">
       あいことばで入る
     </div>

--- a/src/js/dom-dialogs/local-battle-selector/dom/root-inner-html.hbs
+++ b/src/js/dom-dialogs/local-battle-selector/dom/root-inner-html.hbs
@@ -11,23 +11,19 @@
     alt="ローカル対戦（ホスト）をする"
     data-id="local-battle-host"
   >
+    <div class="{{ROOT_CLASS}}__host-icon">✏️</div>
     <div class="{{ROOT_CLASS}}__local-battle-host-title">
-      ローカル対戦<wbr />（ホスト）
+      あいことばを作る
     </div>
-    <div
-      class="{{ROOT_CLASS}}__local-battle-host-description"
-    >{{localBattleHostDescription}}</div>
   </button>
   <button
     class="{{ROOT_CLASS}}__local-battle-guest"
     alt="ローカル対戦（ゲスト）をする"
     data-id="local-battle-guest"
   >
+    <div class="{{ROOT_CLASS}}__guest-icon">🚪</div>
     <div class="{{ROOT_CLASS}}__local-battle-guest-title">
-      ローカル対戦<wbr />（ゲスト）
+      あいことばで入る
     </div>
-    <div
-      class="{{ROOT_CLASS}}__local-battle-guest-description"
-    >{{localBattleGuestDescription}}</div>
   </button>
 </div>

--- a/src/js/dom-dialogs/local-battle-selector/dom/root-inner-html.hbs
+++ b/src/js/dom-dialogs/local-battle-selector/dom/root-inner-html.hbs
@@ -12,7 +12,7 @@
     data-id="local-battle-host"
   >
     <div class="{{ROOT_CLASS}}__local-battle-host-title">
-      ✏️あいことば<wbr />を作る
+      🔑あいことば<wbr />を作る
     </div>
   </button>
   <button
@@ -21,7 +21,7 @@
     data-id="local-battle-guest"
   >
     <div class="{{ROOT_CLASS}}__local-battle-guest-title">
-      🚪あいことば<wbr />で入る
+      🔓あいことば<wbr />で入る
     </div>
   </button>
 </div>

--- a/src/js/dom-dialogs/local-battle-selector/dom/root-inner-html.hbs
+++ b/src/js/dom-dialogs/local-battle-selector/dom/root-inner-html.hbs
@@ -8,7 +8,7 @@
   />
   <button
     class="{{ROOT_CLASS}}__local-battle-host"
-    alt="ローカル対戦（ホスト）をする"
+    alt="あいことばを作る"
     data-id="local-battle-host"
   >
     <div class="{{ROOT_CLASS}}__host-icon">✏️</div>
@@ -18,7 +18,7 @@
   </button>
   <button
     class="{{ROOT_CLASS}}__local-battle-guest"
-    alt="ローカル対戦（ゲスト）をする"
+    alt="あいことばで入る"
     data-id="local-battle-guest"
   >
     <div class="{{ROOT_CLASS}}__guest-icon">🚪</div>

--- a/src/js/dom-dialogs/local-battle-selector/dom/root-inner-html.ts
+++ b/src/js/dom-dialogs/local-battle-selector/dom/root-inner-html.ts
@@ -15,14 +15,8 @@ export const rootInnerHTML = (options: RootInnerHTMLOptions) => {
   const { resources } = options;
   const closerPath =
     resources.paths.find((p) => p.id === PathIds.CLOSER)?.path ?? "";
-  const localBattleHostDescription =
-    "ローカル対戦を開催します、ルームIDをゲストに共有してください";
-  const localBattleGuestDescription =
-    "ホストから共有されたルームIDを入力して、対戦を開始します";
   return template({
     ROOT_CLASS,
     closerPath,
-    localBattleHostDescription,
-    localBattleGuestDescription,
   });
 };

--- a/src/js/dom-scenes/title/dom/root-inner-html.hbs
+++ b/src/js/dom-scenes/title/dom/root-inner-html.hbs
@@ -123,7 +123,7 @@
       <span
         class="{{ROOT_CLASS}}__menu-button-icon"
         aria-hidden="true"
-      >🔑</span>
+      >🔑🔓</span>
       <span class="{{ROOT_CLASS}}__menu-button-label">あいことば対戦</span>
     </button>
     <button class="{{ROOT_CLASS}}__arcade" data-id="arcade">

--- a/src/js/dom-scenes/title/dom/root-inner-html.hbs
+++ b/src/js/dom-scenes/title/dom/root-inner-html.hbs
@@ -123,7 +123,7 @@
       <span
         class="{{ROOT_CLASS}}__menu-button-icon"
         aria-hidden="true"
-      >🤝</span>
+      >🔑</span>
       <span class="{{ROOT_CLASS}}__menu-button-label">あいことば対戦</span>
     </button>
     <button class="{{ROOT_CLASS}}__arcade" data-id="arcade">

--- a/src/js/dom-scenes/title/dom/root-inner-html.hbs
+++ b/src/js/dom-scenes/title/dom/root-inner-html.hbs
@@ -123,8 +123,8 @@
       <span
         class="{{ROOT_CLASS}}__menu-button-icon"
         aria-hidden="true"
-      >👥</span>
-      <span class="{{ROOT_CLASS}}__menu-button-label">ローカル対戦</span>
+      >🤝</span>
+      <span class="{{ROOT_CLASS}}__menu-button-label">あいことば対戦</span>
     </button>
     <button class="{{ROOT_CLASS}}__arcade" data-id="arcade">
       <span


### PR DESCRIPTION
This pull request updates the "local battle" feature to improve clarity and user experience, especially around the naming and appearance of the password-based match system. The changes include renaming the feature to "あいことば対戦" (Password Match), updating button labels and icons, removing redundant descriptions, and refining the layout and styling for better alignment and responsiveness.

**UI/UX Improvements:**

* Renamed the "ローカル対戦" (Local Battle) menu/button to "あいことば対戦" (Password Match), updated the icon from 👥 to 🔑, and changed related button labels and alt texts to clarify the password-based entry system. [[1]](diffhunk://#diff-bf991384bfa8941df5e3ca15732d5604b5c7e54effeb1139b479ec95fc96e3c2L126-R127) [[2]](diffhunk://#diff-76b6572e7bf5039aa34f738155096a778f958736f71f95285f52951eda6928caL11-L31)
* Removed the host/guest descriptions from the password match buttons to reduce clutter and focus on the main actions. [[1]](diffhunk://#diff-76b6572e7bf5039aa34f738155096a778f958736f71f95285f52951eda6928caL11-L31) [[2]](diffhunk://#diff-e2ab904c228230fbe98146aed500a375f6b2bcaff87a51c54fd685cb4dc2151aL18-L26)

**Styling and Layout Enhancements:**

* Improved the layout of the local battle selector by making host/guest buttons use flexbox for vertical centering, increasing their minimum height, and aligning content centrally.
* Adjusted the local battle selector's width calculation for better responsiveness and removed unnecessary box shadows for a cleaner look. [[1]](diffhunk://#diff-bb02a2316789262dcbf8a64b6fab684e540a0a5b177d7fc7d4fe88a7624b6d5cL43-L47) [[2]](diffhunk://#diff-bb02a2316789262dcbf8a64b6fab684e540a0a5b177d7fc7d4fe88a7624b6d5cL7-L10)
* Updated the grid layout of the main menu to swap the positions of "local battle" and "net battle" for a more intuitive arrangement.

**Code Cleanup:**

* Removed unused CSS classes for button descriptions to keep the stylesheet tidy.