### PR TITLE
WebRTCダイアログのスタイルを調整

### DIFF
--- a/src/css/local-battle-guest.css
+++ b/src/css/local-battle-guest.css
@@ -65,6 +65,5 @@
   border-radius: var(--button-border-radius);
   border: var(--button-border);
   height: calc(var(--responsive-font-size) * 3);
-  min-width: calc(var(--responsive-font-size) * 10);
   width: calc(var(--responsive-font-size) * 30);
 }

--- a/src/css/local-battle-guest.css
+++ b/src/css/local-battle-guest.css
@@ -39,6 +39,7 @@
     var(--dialog-padding) var(--dialog-padding) var(--dialog-padding);
   display: flex;
   flex-direction: column;
+  align-items: center;
   justify-content: center;
   gap: calc(var(--responsive-font-size) * 0.5);
 }
@@ -65,6 +66,7 @@
   box-sizing: border-box;
   font-size: calc(var(--responsive-font-size) * 1);
   text-align: center;
+  width: calc(var(--responsive-font-size) * 30);
 }
 
 .local-battle-guest__battle-start {
@@ -75,4 +77,5 @@
   border: var(--button-border);
   height: calc(var(--responsive-font-size) * 3);
   min-width: calc(var(--responsive-font-size) * 10);
+  width: calc(var(--responsive-font-size) * 30);
 }

--- a/src/css/local-battle-guest.css
+++ b/src/css/local-battle-guest.css
@@ -26,29 +26,20 @@
 .local-battle-guest__dialog {
   --dialog-padding: calc(var(--responsive-font-size) * 2);
 
-  top: 50vh;
-  top: 50dvh;
-  left: 50vw;
-  left: 50dvw;
-  width: min(
-    calc(
-      100vw - var(--safe-area-right) - var(--safe-area-left) -
-        var(--closer-width) * 0.5
-    ),
-    60vw
-  );
-  transform: translate(-50%, -50%);
+  width: 100vw;
+  width: 100dvw;
+  height: 100vh;
+  height: 100dvh;
   color: var(--font-color);
   background-color: var(--background-color);
   position: absolute;
-  border: var(--dialog-border);
-  border-radius: var(--dialog-border-radius);
   z-index: var(--zindex-dialog);
   box-sizing: border-box;
   padding: max(var(--dialog-padding), calc(var(--closer-height) / 2))
     var(--dialog-padding) var(--dialog-padding) var(--dialog-padding);
   display: flex;
   flex-direction: column;
+  justify-content: center;
   gap: calc(var(--responsive-font-size) * 0.5);
 }
 
@@ -56,8 +47,8 @@
   width: var(--closer-width);
   height: var(--closer-height);
   position: absolute;
-  top: calc(var(--closer-width) * -0.5);
-  left: calc(var(--closer-height) * -0.5);
+  top: max(var(--safe-area-top), calc(var(--closer-width) * 0.3));
+  left: max(var(--safe-area-left), calc(var(--closer-height) * 0.3));
 }
 
 .local-battle-guest__description {

--- a/src/css/local-battle-guest.css
+++ b/src/css/local-battle-guest.css
@@ -12,17 +12,6 @@
   }
 }
 
-.local-battle-guest__background {
-  position: absolute;
-  width: 100vw;
-  width: 100dvw;
-  height: 100vh;
-  height: 100dvh;
-  background-color: #000;
-  opacity: 0.5;
-  z-index: var(--zindex-background);
-}
-
 .local-battle-guest__dialog {
   --dialog-padding: calc(var(--responsive-font-size) * 2);
 

--- a/src/css/local-battle-host.css
+++ b/src/css/local-battle-host.css
@@ -19,12 +19,9 @@
   width: 100dvw;
   height: 100vh;
   height: 100dvh;
-  transform: translate(-50%, -50%);
   color: var(--font-color);
   background-color: var(--background-color);
   position: absolute;
-  border: var(--dialog-border);
-  border-radius: var(--dialog-border-radius);
   z-index: var(--zindex-dialog);
   box-sizing: border-box;
   padding: max(var(--dialog-padding), calc(var(--closer-height) / 2))
@@ -40,8 +37,8 @@
   width: var(--closer-width);
   height: var(--closer-height);
   position: absolute;
-  top: calc(var(--closer-width) * -0.5);
-  left: calc(var(--closer-height) * -0.5);
+  top: max(var(--safe-area-top), calc(var(--closer-width) * 0.3));
+  left: max(var(--safe-area-left), calc(var(--closer-height) * 0.3));
 }
 
 .local-battle-host__password-label {

--- a/src/css/local-battle-host.css
+++ b/src/css/local-battle-host.css
@@ -12,32 +12,13 @@
   }
 }
 
-.local-battle-host__background {
-  position: absolute;
+.local-battle-host__dialog {
+  --dialog-padding: calc(var(--responsive-font-size) * 2);
+
   width: 100vw;
   width: 100dvw;
   height: 100vh;
   height: 100dvh;
-  background-color: #000;
-  opacity: 0.5;
-  z-index: var(--zindex-background);
-}
-
-.local-battle-host__dialog {
-  --dialog-padding: calc(var(--responsive-font-size) * 2);
-
-  top: 50vh;
-  top: 50dvh;
-  left: 50vw;
-  left: 50dvw;
-  width: min(
-    calc(
-      100vw - var(--safe-area-right) - var(--safe-area-left) -
-        var(--closer-width) * 0.5
-    ),
-    90vw
-  );
-  min-height: 60vh;
   transform: translate(-50%, -50%);
   color: var(--font-color);
   background-color: var(--background-color);

--- a/src/css/private-match-guest.css
+++ b/src/css/private-match-guest.css
@@ -12,6 +12,17 @@
   }
 }
 
+.private-match-guest__background {
+  position: absolute;
+  width: 100vw;
+  width: 100dvw;
+  height: 100vh;
+  height: 100dvh;
+  background-color: #000;
+  opacity: 0.5;
+  z-index: var(--zindex-background);
+}
+
 .private-match-guest__dialog {
   --dialog-padding: calc(var(--responsive-font-size) * 2);
 

--- a/src/css/private-match-guest.css
+++ b/src/css/private-match-guest.css
@@ -12,17 +12,6 @@
   }
 }
 
-.private-match-guest__background {
-  position: absolute;
-  width: 100vw;
-  width: 100dvw;
-  height: 100vh;
-  height: 100dvh;
-  background-color: #000;
-  opacity: 0.5;
-  z-index: var(--zindex-background);
-}
-
 .private-match-guest__dialog {
   --dialog-padding: calc(var(--responsive-font-size) * 2);
 

--- a/src/js/dom-dialogs/local-battle-guest/dom/extract-element.ts
+++ b/src/js/dom-dialogs/local-battle-guest/dom/extract-element.ts
@@ -1,12 +1,4 @@
 /**
- * バックグラウンドを抽出する
- * @param root ルートHTML要素
- * @returns 抽出したもの
- */
-export const extractBackGround = (root: HTMLElement): HTMLElement =>
-  root.querySelector(`[data-id="background"]`) ?? document.createElement("div");
-
-/**
  * クロージャーを抽出する
  * @param root ルートHTML要素
  * @returns 抽出したもの

--- a/src/js/dom-dialogs/local-battle-guest/dom/root-inner-html.hbs
+++ b/src/js/dom-dialogs/local-battle-guest/dom/root-inner-html.hbs
@@ -1,4 +1,3 @@
-<div class="{{ROOT_CLASS}}__background" data-id="background"></div>
 <div class="{{ROOT_CLASS}}__dialog">
   <img
     class="{{ROOT_CLASS}}__closer"

--- a/src/js/dom-dialogs/local-battle-guest/procedure/create-local-battle-guest-dialog-props.ts
+++ b/src/js/dom-dialogs/local-battle-guest/procedure/create-local-battle-guest-dialog-props.ts
@@ -6,7 +6,6 @@ import { SOUND_IDS } from "../../../resource/sound/ids";
 import { SEPlayerContainer } from "../../../se/se-player";
 import { ROOT_CLASS } from "../dom/class-name";
 import {
-  extractBackGround,
   extractBattleStart,
   extractCloser,
   extractPassword,
@@ -31,8 +30,6 @@ export const createLocalBattleGuestDialogProps = (
   root.className = ROOT_CLASS;
   root.innerHTML = rootInnerHTML(options);
 
-  const backGround = extractBackGround(root);
-
   const closer = extractCloser(root);
 
   const password = extractPassword(root);
@@ -53,7 +50,6 @@ export const createLocalBattleGuestDialogProps = (
 
   return {
     root,
-    backGround,
     closer,
     password,
     battleStartButton,

--- a/src/js/dom-dialogs/local-battle-guest/props.ts
+++ b/src/js/dom-dialogs/local-battle-guest/props.ts
@@ -14,8 +14,6 @@ export type BattleStartPayload = {
 export type LocalBattleGuestDialogProps = SEPlayerContainer & {
   /** ルートHTML要素 */
   root: HTMLElement;
-  /** バックグラウンド */
-  backGround: HTMLElement;
   /** クロージャー */
   closer: HTMLElement;
   /** あいことば入力欄 */

--- a/src/js/dom-dialogs/local-battle-host/dom/extract-element.ts
+++ b/src/js/dom-dialogs/local-battle-host/dom/extract-element.ts
@@ -5,11 +5,3 @@
  */
 export const extractCloser = (root: HTMLElement): HTMLElement =>
   root.querySelector(`[data-id="closer"]`) ?? document.createElement("div");
-
-/**
- * バックグラウンドを抽出する
- * @param root ルートHTML要素
- * @returns 抽出結果
- */
-export const extractBackGround = (root: HTMLElement): HTMLElement =>
-  root.querySelector(`[data-id="background"]`) ?? document.createElement("div");

--- a/src/js/dom-dialogs/local-battle-host/dom/root-inner-html.hbs
+++ b/src/js/dom-dialogs/local-battle-host/dom/root-inner-html.hbs
@@ -1,4 +1,3 @@
-<div class="{{ROOT_CLASS}}__background" data-id="background"></div>
 <div class="{{ROOT_CLASS}}__dialog">
   <img
     class="{{ROOT_CLASS}}__closer"

--- a/src/js/dom-dialogs/local-battle-host/procedures/create-local-battle-host-dialog-props.ts
+++ b/src/js/dom-dialogs/local-battle-host/procedures/create-local-battle-host-dialog-props.ts
@@ -5,7 +5,7 @@ import { createEmptySoundResource } from "../../../resource/sound/empty-sound-re
 import { SOUND_IDS } from "../../../resource/sound/ids";
 import { SEPlayerContainer } from "../../../se/se-player";
 import { ROOT_CLASS } from "../dom/class-name";
-import { extractBackGround, extractCloser } from "../dom/extract-element";
+import { extractCloser } from "../dom/extract-element";
 import { rootInnerHTML, RootInnerHTMLOptions } from "../dom/root-inner-html";
 
 /** ローカル対戦ホストダイアログのプロパティ生成オプション */
@@ -25,8 +25,6 @@ export const createLocalBattleHostDialogProps = (
   root.className = ROOT_CLASS;
   root.innerHTML = rootInnerHTML(options);
 
-  const backGround = extractBackGround(root);
-
   const closer = extractCloser(root);
 
   const closeButtonSound =
@@ -39,7 +37,6 @@ export const createLocalBattleHostDialogProps = (
 
   return {
     root,
-    backGround,
     closer,
 
     se,

--- a/src/js/dom-dialogs/local-battle-host/props.ts
+++ b/src/js/dom-dialogs/local-battle-host/props.ts
@@ -8,8 +8,6 @@ import { SEPlayerContainer } from "../../se/se-player";
 export type LocalBattleHostDialogProps = SEPlayerContainer & {
   /** ルートHTML要素 */
   root: HTMLElement;
-  /** バックグラウンド */
-  backGround: HTMLElement;
   /** クロージャー */
   closer: HTMLElement;
 


### PR DESCRIPTION
This pull request removes the background overlay element and its related code from both the local battle host and guest dialogs, and updates the dialog styles to use a full-screen modal approach. It also makes several style adjustments for improved alignment and sizing of dialog components.

**Removal of background overlay and related code:**

* Removed the background overlay element from both the host and guest dialog HTML templates, and deleted all code related to extracting and referencing this background element in both dialog implementations (`extractBackGround`, related imports, and type properties). [[1]](diffhunk://#diff-150d34a1e82fd88689cfccc348ccc1c31d4e24d86c8b8415a5a35945be5f446aL1-L8) [[2]](diffhunk://#diff-53b98ace8bf0f44d7ad4a677f2954375a1a064949760aec2541838929bb1eb91L1) [[3]](diffhunk://#diff-e2bb353cb3b899ba13164f14f28f7c95c2b7124b0e98ec645810ea82870fbc93L9) [[4]](diffhunk://#diff-e2bb353cb3b899ba13164f14f28f7c95c2b7124b0e98ec645810ea82870fbc93L34-L35) [[5]](diffhunk://#diff-e2bb353cb3b899ba13164f14f28f7c95c2b7124b0e98ec645810ea82870fbc93L56) [[6]](diffhunk://#diff-7fe9816714ba6f5770169b87aa17c13caa3a218a266af7d4c6fa5e57bd89cdffL17-L18) [[7]](diffhunk://#diff-382be4aa659551d8ff8507aee80ad76ecee20f75268e0bbd40ba06b084c90106L8-L15) [[8]](diffhunk://#diff-555a1494553100cbd9cfd707d454474c228652e748c10a84b03be9876691d35eL1) [[9]](diffhunk://#diff-3f6bce68aff7ccc95836ed6291f3493be7968e6d014d211737b0388632ad11bcL8-R8) [[10]](diffhunk://#diff-3f6bce68aff7ccc95836ed6291f3493be7968e6d014d211737b0388632ad11bcL28-L29) [[11]](diffhunk://#diff-3f6bce68aff7ccc95836ed6291f3493be7968e6d014d211737b0388632ad11bcL42) [[12]](diffhunk://#diff-35b7496949c9d3b4e5a9ec7efd6cb788b85aba59fa297307ef6d8b694883f2d3L11-L12)

**Dialog styling updates:**

* Updated `.local-battle-guest__dialog` and `.local-battle-host__dialog` to use full viewport width and height, center their content, and removed border and border-radius for a more modern, modal-like appearance. [[1]](diffhunk://#diff-d63a0e12c948f61be880aaf2add5e368ffb216b06267d1126b47ced7982430d5L29-R52) [[2]](diffhunk://#diff-b62a6bbc35306fcd4866e728dcc5f52afd45b3cbec3d7385c23ef2cd3d0409d6L15-L46)
* Adjusted the position of the closer button to respect safe areas and improved its placement. [[1]](diffhunk://#diff-d63a0e12c948f61be880aaf2add5e368ffb216b06267d1126b47ced7982430d5L29-R52) [[2]](diffhunk://#diff-b62a6bbc35306fcd4866e728dcc5f52afd45b3cbec3d7385c23ef2cd3d0409d6L62-R41)

**Component sizing improvements:**

* Set explicit width for `.local-battle-guest__description` and `.local-battle-guest__battle-start` to ensure consistent sizing and alignment. [[1]](diffhunk://#diff-d63a0e12c948f61be880aaf2add5e368ffb216b06267d1126b47ced7982430d5R69) [[2]](diffhunk://#diff-d63a0e12c948f61be880aaf2add5e368ffb216b06267d1126b47ced7982430d5R80)