### PR TITLE
マッチングダイアログを全画面表示にした

### DIFF
--- a/src/css/matching.css
+++ b/src/css/matching.css
@@ -1,11 +1,6 @@
 /** マッチング ダイアログ */
 @media (orientation: landscape) {
   .matching {
-    --dialog-width: calc(min(var(--dialog-height) * 16 / 9, 50vw));
-    --dialog-height: calc(var(--responsive-font-size) * 10);
-    --control-button-width: calc(var(--responsive-font-size) * 10);
-    --control-button-height: calc(var(--responsive-font-size) * 3);
-
     display: block;
   }
 }
@@ -28,8 +23,6 @@
 }
 
 .matching__dialog {
-  --dialog-padding: var(--responsive-font-size);
-
   width: 100vw;
   width: 100dvw;
   height: 100vh;

--- a/src/css/matching.css
+++ b/src/css/matching.css
@@ -11,17 +11,6 @@
   }
 }
 
-.matching__background {
-  position: absolute;
-  width: 100vw;
-  width: 100dvw;
-  height: 100vh;
-  height: 100dvh;
-  background-color: #000;
-  opacity: 0.5;
-  z-index: var(--zindex-background);
-}
-
 .matching__dialog {
   width: 100vw;
   width: 100dvw;

--- a/src/css/matching.css
+++ b/src/css/matching.css
@@ -30,12 +30,10 @@
 .matching__dialog {
   --dialog-padding: var(--responsive-font-size);
 
-  width: var(--dialog-width);
-  height: var(--dialog-height);
-  top: 50vh;
-  top: 50dvh;
-  left: 50%;
-  transform: translate(-50%, -50%);
+  width: 100vw;
+  width: 100dvw;
+  height: 100vh;
+  height: 100dvh;
   color: var(--font-color);
   font-size: var(--responsive-font-size);
   background-color: var(--background-color);
@@ -44,19 +42,16 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  border: var(--dialog-border);
-  border-radius: var(--dialog-border-radius);
   z-index: var(--zindex-dialog);
   box-sizing: border-box;
 }
 
 .matching__closer {
-  position: absolute;
-  top: calc(var(--closer-height) * -0.5);
-  left: calc(var(--closer-width) * -0.5);
   width: var(--closer-width);
   height: var(--closer-height);
-  z-index: var(--zindex-close);
+  position: absolute;
+  top: max(var(--safe-area-top), calc(var(--closer-width) * 0.3));
+  left: max(var(--safe-area-left), calc(var(--closer-height) * 0.3));
 }
 
 .matching__caption {

--- a/src/js/dom-dialogs/matching/matching-dialog.ts
+++ b/src/js/dom-dialogs/matching/matching-dialog.ts
@@ -31,7 +31,6 @@ function rootInnerHTML(ids: DataIDs, resources: Resources): string {
   const closerPath =
     resources.paths.find((v) => v.id === PathIds.CLOSER)?.path ?? "";
   return `
-    <div class="${ROOT_CLASS}__background"></div>
     <div class="${ROOT_CLASS}__dialog">
       <img class="${ROOT_CLASS}__closer" alt="閉じる" src="${closerPath}" data-id="${ids.closer}">
       <span class="${ROOT_CLASS}__caption">マッチング中......</span>    


### PR DESCRIPTION
This pull request updates the styling and structure of the matching dialog to make it fully cover the viewport and adjusts the positioning of the close button for better usability, especially on devices with safe areas. Additionally, it removes the background overlay element from the dialog's HTML.

**Dialog Layout and Styling Updates:**

* The `.matching__dialog` now uses `100vw`/`100vh` and `100dvw`/`100dvh` for width and height, making the dialog always cover the entire viewport. Previous centering and sizing styles were removed.
* Borders and border-radius have been removed from `.matching__dialog`, further simplifying its appearance.

**Close Button Positioning Improvements:**

* The `.matching__closer` (close button) now uses `position: absolute` with `top` and `left` set using `max()` to respect CSS safe areas, improving accessibility on devices with notches or rounded corners.

**DOM Structure Simplification:**

* The background overlay `<div class="matching__background"></div>` has been removed from the dialog's HTML, reducing unnecessary markup.