### PR TITLE
プライベートマッチ用ダイアログをひながら5文字対応にした

### DIFF
--- a/src/css/private-match-guest.css
+++ b/src/css/private-match-guest.css
@@ -27,7 +27,7 @@
   padding: max(var(--dialog-padding), calc(var(--closer-height)))
     var(--dialog-padding) var(--dialog-padding) var(--dialog-padding);
   display: grid;
-  grid-template-rows: 1fr auto 1fr auto 1fr;
+  grid-template-rows: 1fr auto auto auto 1fr;
   justify-items: center;
   font-size: calc(var(--responsive-font-size) * 1);
 }
@@ -52,11 +52,12 @@
   border-radius: var(--button-border-radius);
   border: var(--sub-button-border);
   height: calc(var(--responsive-font-size) * 3);
-  min-width: calc(var(--responsive-font-size) * 12);
+  min-width: calc(var(--responsive-font-size) * 22);
 }
 
 .private-match-guest__separator {
   align-self: center;
+  margin: calc(var(--responsive-font-size) * 1) 0;
 }
 
 .private-match-guest__room-id-description {
@@ -78,6 +79,7 @@
   padding: var(--button-border-radius);
   box-sizing: border-box;
   font-size: calc(var(--responsive-font-size) * 1);
+  min-width: calc(var(--responsive-font-size) * 14.5);
 }
 
 .private-match-guest__enter {

--- a/src/css/private-match-guest.css
+++ b/src/css/private-match-guest.css
@@ -24,10 +24,11 @@
   position: absolute;
   z-index: var(--zindex-dialog);
   box-sizing: border-box;
-  padding: max(var(--dialog-padding), calc(var(--closer-height) / 2))
+  padding: max(var(--dialog-padding), calc(var(--closer-height)))
     var(--dialog-padding) var(--dialog-padding) var(--dialog-padding);
   display: grid;
-  text-align: center;
+  grid-template-rows: 1fr auto 1fr auto 1fr;
+  justify-items: center;
   font-size: calc(var(--responsive-font-size) * 1);
 }
 
@@ -40,6 +41,7 @@
 }
 
 .private-match-guest__qr-code-description {
+  align-self: end;
   margin-bottom: calc(var(--responsive-font-size) * 0.5);
 }
 
@@ -50,14 +52,15 @@
   border-radius: var(--button-border-radius);
   border: var(--sub-button-border);
   height: calc(var(--responsive-font-size) * 3);
-  min-width: calc(var(--responsive-font-size) * 7);
+  min-width: calc(var(--responsive-font-size) * 12);
 }
 
 .private-match-guest__separator {
-  margin: calc(var(--responsive-font-size) * 1) 0;
+  align-self: center;
 }
 
 .private-match-guest__room-id-description {
+  align-self: end;
   margin-bottom: calc(var(--responsive-font-size) * 0.5);
 }
 

--- a/src/css/private-match-guest.css
+++ b/src/css/private-match-guest.css
@@ -12,36 +12,21 @@
   }
 }
 
-.private-match-guest__background {
-  position: absolute;
+.private-match-guest__dialog {
+  --dialog-padding: calc(var(--responsive-font-size) * 2);
+
   width: 100vw;
   width: 100dvw;
   height: 100vh;
   height: 100dvh;
-  background-color: #000;
-  opacity: 0.5;
-  z-index: var(--zindex-background);
-}
-
-.private-match-guest__dialog {
-  --dialog-padding: calc(var(--responsive-font-size) * 2);
-
-  top: 50dvh;
-  left: 50dvw;
-  transform: translate(-50%, -50%);
   color: var(--font-color);
   background-color: var(--background-color);
   position: absolute;
-  border: var(--dialog-border);
-  border-radius: var(--dialog-border-radius);
   z-index: var(--zindex-dialog);
   box-sizing: border-box;
   padding: max(var(--dialog-padding), calc(var(--closer-height) / 2))
     var(--dialog-padding) var(--dialog-padding) var(--dialog-padding);
-  min-width: calc(var(--responsive-font-size) * 35);
-  min-height: 30vh;
   display: grid;
-  grid-template-rows: auto 1fr auto auto;
   text-align: center;
   font-size: calc(var(--responsive-font-size) * 1);
 }
@@ -50,8 +35,8 @@
   width: var(--closer-width);
   height: var(--closer-height);
   position: absolute;
-  top: calc(var(--closer-width) * -0.5);
-  left: calc(var(--closer-height) * -0.5);
+  top: max(var(--safe-area-top), calc(var(--closer-width) * 0.3));
+  left: max(var(--safe-area-left), calc(var(--closer-height) * 0.3));
 }
 
 .private-match-guest__qr-code-description {

--- a/src/css/private-match-host.css
+++ b/src/css/private-match-host.css
@@ -52,7 +52,7 @@
 .private-match-host__room-id {
   display: grid;
   grid-template-areas:
-    "description copy"
+    "description description"
     "value       copy";
   gap: 0 calc(var(--responsive-font-size) * 0.5);
 }

--- a/src/js/dom-dialogs/private-match-guest/dom/root-inner-html.hbs
+++ b/src/js/dom-dialogs/private-match-guest/dom/root-inner-html.hbs
@@ -16,7 +16,7 @@
     class="{{ROOT_CLASS}}__start-qr-code-reader"
     data-id="start-qr-code-reader"
   >
-    📷カメラを起動
+    カメラを起動
   </button>
   <div class="{{ROOT_CLASS}}__separator">or</div>
   <div

--- a/src/js/dom-dialogs/private-match-guest/dom/root-inner-html.hbs
+++ b/src/js/dom-dialogs/private-match-guest/dom/root-inner-html.hbs
@@ -16,7 +16,7 @@
     class="{{ROOT_CLASS}}__start-qr-code-reader"
     data-id="start-qr-code-reader"
   >
-    カメラを起動
+    📷カメラを起動
   </button>
   <div class="{{ROOT_CLASS}}__separator">or</div>
   <div

--- a/src/js/dom-dialogs/private-match-guest/dom/root-inner-html.hbs
+++ b/src/js/dom-dialogs/private-match-guest/dom/root-inner-html.hbs
@@ -1,4 +1,3 @@
-<div class="{{ROOT_CLASS}}__background"></div>
 <div
   class="{{ROOT_CLASS}}__dummy-qr-code-reader"
   data-id="dummy-qr-code-reader"

--- a/src/js/qr-code/private-match-qr-code.ts
+++ b/src/js/qr-code/private-match-qr-code.ts
@@ -23,6 +23,7 @@ export const drawPrivateMatchQRCode = async (
 
 /**
  * 任意のQRコードテキストを受け取り、それがプライベートマッチQRコードである場合にルームIDを抽出する
+ * 現状ではひらがな5文字がルームIDとして正しいフォーマットである
  * フォーマットが違う場合はnullを返す
  * @param qrCodeStr QRコード文字列
  * @returns 抽出結果
@@ -30,7 +31,7 @@ export const drawPrivateMatchQRCode = async (
 export const extractRoomIDFromPrivateMatchQRCodeText = (
   qrCodeStr: string,
 ): string | null => {
-  const regExp = /^gbraver-burst-private-match:([A-Za-z0-9_-]+)$/;
+  const regExp = /^gbraver-burst-private-match:([ぁ-ん]{5})$/;
   const matched = qrCodeStr.match(regExp);
   return matched?.at(1) ?? null;
 };

--- a/stories/private-match-host-dialog.stories.ts
+++ b/stories/private-match-host-dialog.stories.ts
@@ -9,7 +9,7 @@ export default {
 export const dialog = domStub((params) => {
   const dialog = new PrivateMatchHostDialog({
     ...params,
-    roomID: "V1StGXR8_Z5jdHi6B-myT",
+    roomID: "あかんやろ",
   });
   dialog.notifyDialogClosed().subscribe(() => {
     console.log("dialog closed");

--- a/test/js/qr-code/extract-room-id-from-private-match-qr-code-text.test.ts
+++ b/test/js/qr-code/extract-room-id-from-private-match-qr-code-text.test.ts
@@ -1,19 +1,31 @@
 import { extractRoomIDFromPrivateMatchQRCodeText } from "../../../src/js/qr-code/private-match-qr-code";
 
-test("正しいプライベートマッチQRコードテキストなら、ルームIDを抽出できる", () => {
-  const roomID = "tD0eDEtIFk2kGJzo6SiNY";
+test("ひらがな5文字は正しいフォーマットなので、ルームIDを抽出できる", () => {
+  const roomID = "あかんやろ";
   const text = `gbraver-burst-private-match:${roomID}`;
   expect(extractRoomIDFromPrivateMatchQRCodeText(text)).toBe(roomID);
 });
 
-test("プライベートマッチQRコードテキストなら、ルームIDが抽出できない", () => {
-  const roomID = "tD0eDEtIFk2kGJzo6SiNY";
+test("ひらがな5文字以外は不正なフォーマットなので、ルームIDが抽出できない", () => {
+  const roomID = "あかんやろがな";
+  const text = `gbraver-burst-private-match:${roomID}`;
+  expect(extractRoomIDFromPrivateMatchQRCodeText(text)).toBe(null);
+});
+
+test("ルームIDが空文字だと、ルームIDが抽出できない", () => {
+  const roomID = "";
+  const text = `gbraver-burst-private-match:${roomID}`;
+  expect(extractRoomIDFromPrivateMatchQRCodeText(text)).toBe(null);
+});
+
+test("プレフィックスが不正なら、ルームIDが抽出できない", () => {
+  const roomID = "あかんやろ";
   const text = `invalid-gbraver-burst-private-match:${roomID}`;
   expect(extractRoomIDFromPrivateMatchQRCodeText(text)).toBe(null);
 });
 
 test("スペースが前後に含まれていても、ルームIDが抽出できない", () => {
-  const roomID = "tD0eDEtIFk2kGJzo6SiNY";
+  const roomID = "あかんやろ";
   const text = ` gbraver-burst-private-match:${roomID} `;
   expect(extractRoomIDFromPrivateMatchQRCodeText(text)).toBe(null);
 });


### PR DESCRIPTION
This pull request refactors the way private match room IDs are handled throughout the codebase, enforcing that room IDs must now be exactly five hiragana characters. It also includes several UI and test updates to support this change and improve the dialog appearance.

**Room ID Format Enforcement**

* Updated the `extractRoomIDFromPrivateMatchQRCodeText` function to only accept room IDs that are exactly five hiragana characters, instead of the previous alphanumeric format.
* Updated related tests in `extract-room-id-from-private-match-qr-code-text.test.ts` to reflect the new validation rules, including new cases for invalid formats.
* Changed the sample room ID in the storybook dialog to a five-hiragana string to match the new requirements.

**UI and Layout Adjustments**

* Removed the `.private-match-guest__background` overlay and adjusted the `.private-match-guest__dialog` styles for improved centering, padding, and layout; also updated button and description element sizing and alignment for better appearance and usability. [[1]](diffhunk://#diff-42556c081571046d3d17300e0664c6adf805834ab4adce3a03884fc51cfd1e44L15-R44) [[2]](diffhunk://#diff-42556c081571046d3d17300e0664c6adf805834ab4adce3a03884fc51cfd1e44L68-R64) [[3]](diffhunk://#diff-42556c081571046d3d17300e0664c6adf805834ab4adce3a03884fc51cfd1e44R82)
* Removed the background overlay element from the guest dialog HTML template.
* Adjusted the host dialog room ID display to use a single-line description layout.