### PR TITLE
あいことば対戦ゲストのダイアログを修正

### DIFF
--- a/src/css/local-battle-guest.css
+++ b/src/css/local-battle-guest.css
@@ -24,7 +24,7 @@
   position: absolute;
   z-index: var(--zindex-dialog);
   box-sizing: border-box;
-  padding: max(var(--dialog-padding), calc(var(--closer-height) / 2))
+  padding: max(var(--dialog-padding), var(--closer-height))
     var(--dialog-padding) var(--dialog-padding) var(--dialog-padding);
   display: flex;
   flex-direction: row;
@@ -40,12 +40,6 @@
   top: max(var(--safe-area-top), calc(var(--closer-width) * 0.3));
   left: max(var(--safe-area-left), calc(var(--closer-height) * 0.3));
 }
-
-/* .local-battle-guest__description {
-  text-align: center;
-  font-size: calc(var(--responsive-font-size) * 1.2);
-  margin-bottom: calc(var(--responsive-font-size) * 0.5);
-} */
 
 .local-battle-guest__password {
   height: calc(var(--responsive-font-size) * 3);

--- a/src/css/local-battle-guest.css
+++ b/src/css/local-battle-guest.css
@@ -27,7 +27,7 @@
   padding: max(var(--dialog-padding), calc(var(--closer-height) / 2))
     var(--dialog-padding) var(--dialog-padding) var(--dialog-padding);
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   align-items: center;
   justify-content: center;
   gap: calc(var(--responsive-font-size) * 0.5);
@@ -41,11 +41,11 @@
   left: max(var(--safe-area-left), calc(var(--closer-height) * 0.3));
 }
 
-.local-battle-guest__description {
+/* .local-battle-guest__description {
   text-align: center;
   font-size: calc(var(--responsive-font-size) * 1.2);
   margin-bottom: calc(var(--responsive-font-size) * 0.5);
-}
+} */
 
 .local-battle-guest__password {
   height: calc(var(--responsive-font-size) * 3);
@@ -54,7 +54,6 @@
   padding: var(--button-border-radius);
   box-sizing: border-box;
   font-size: calc(var(--responsive-font-size) * 1);
-  text-align: center;
   width: calc(var(--responsive-font-size) * 30);
 }
 
@@ -65,5 +64,5 @@
   border-radius: var(--button-border-radius);
   border: var(--button-border);
   height: calc(var(--responsive-font-size) * 3);
-  width: calc(var(--responsive-font-size) * 30);
+  min-width: calc(var(--responsive-font-size) * 12);
 }

--- a/src/js/dom-dialogs/local-battle-guest/dom/root-inner-html.hbs
+++ b/src/js/dom-dialogs/local-battle-guest/dom/root-inner-html.hbs
@@ -5,7 +5,6 @@
     src="{{closerPath}}"
     data-id="closer"
   />
-  <div class="{{ROOT_CLASS}}__description">あいことばを入れてね。</div>
   <input class="{{ROOT_CLASS}}__password" type="text" data-id="password" />
   <button
     class="{{ROOT_CLASS}}__battle-start"


### PR DESCRIPTION
This pull request makes several changes to the local battle guest dialog to improve its layout and simplify its appearance. The dialog now uses a horizontal (row) layout, the description text has been removed, and input sizing has been adjusted for better responsiveness.

**Layout and UI Simplification:**

* Changed the main dialog container in `local-battle-guest.css` to use `flex-direction: row` instead of column, and adjusted padding for better alignment.
* Removed the `.local-battle-guest__description` element and its associated styles, and deleted the description text from the dialog template. [[1]](diffhunk://#diff-53b98ace8bf0f44d7ad4a677f2954375a1a064949760aec2541838929bb1eb91L8) [[2]](diffhunk://#diff-d63a0e12c948f61be880aaf2add5e368ffb216b06267d1126b47ced7982430d5L44-L57)

**Input Field Adjustments:**

* Updated the password input field's width to use `min-width` instead of a fixed width for improved responsiveness, and removed text centering. [[1]](diffhunk://#diff-d63a0e12c948f61be880aaf2add5e368ffb216b06267d1126b47ced7982430d5L68-R61) [[2]](diffhunk://#diff-d63a0e12c948f61be880aaf2add5e368ffb216b06267d1126b47ced7982430d5L44-L57)