### PR TITLE
あいことば対戦ゲストのダイアログを修正

### DIFF
--- a/src/css/local-battle-guest.css
+++ b/src/css/local-battle-guest.css
@@ -52,7 +52,6 @@
   font-size: calc(var(--responsive-font-size) * 1.3);
 }
 
-
 .local-battle-guest__arrow {
   color: #ff4500;
 }

--- a/src/css/local-battle-guest.css
+++ b/src/css/local-battle-guest.css
@@ -27,10 +27,8 @@
   padding: max(var(--dialog-padding), var(--closer-height))
     var(--dialog-padding) var(--dialog-padding) var(--dialog-padding);
   display: flex;
-  flex-direction: row;
   align-items: center;
   justify-content: center;
-  gap: calc(var(--responsive-font-size) * 0.5);
 }
 
 .local-battle-guest__closer {
@@ -41,17 +39,37 @@
   left: max(var(--safe-area-left), calc(var(--closer-height) * 0.3));
 }
 
+.local-battle-guest__content {
+  display: grid;
+  grid-template:
+    "description description" auto
+    "password battle-start" auto / auto auto;
+  gap: calc(var(--responsive-font-size) * 0.5);
+}
+
+.local-battle-guest__description {
+  grid-area: description;
+  font-size: calc(var(--responsive-font-size) * 1.3);
+}
+
+
+.local-battle-guest__arrow {
+  color: #ff4500;
+}
+
 .local-battle-guest__password {
+  grid-area: password;
   height: calc(var(--responsive-font-size) * 3);
   border: var(--sub-button-border);
   border-radius: var(--button-border-radius);
   padding: var(--button-border-radius);
   box-sizing: border-box;
   font-size: calc(var(--responsive-font-size) * 1);
-  width: calc(var(--responsive-font-size) * 30);
+  width: calc(var(--responsive-font-size) * 20);
 }
 
 .local-battle-guest__battle-start {
+  grid-area: battle-start;
   font-size: calc(var(--responsive-font-size) * 1);
   color: var(--button-font-color);
   background-color: var(--button-background-color);

--- a/src/js/dom-dialogs/local-battle-guest/dom/root-inner-html.hbs
+++ b/src/js/dom-dialogs/local-battle-guest/dom/root-inner-html.hbs
@@ -5,9 +5,15 @@
     src="{{closerPath}}"
     data-id="closer"
   />
-  <input class="{{ROOT_CLASS}}__password" type="text" data-id="password" />
-  <button
-    class="{{ROOT_CLASS}}__battle-start"
-    data-id="battle-start"
-  >バトルスタート</button>
+  <div class="{{ROOT_CLASS}}__content">
+    <div class="{{ROOT_CLASS}}__description">
+      あいことばを入れてね
+      <span class="{{ROOT_CLASS}}__arrow">⬇</span>
+    </div>
+    <input class="{{ROOT_CLASS}}__password" type="text" data-id="password" />
+    <button
+      class="{{ROOT_CLASS}}__battle-start"
+      data-id="battle-start"
+    >バトルスタート</button>
+  </div>
 </div>


### PR DESCRIPTION
This pull request refactors the layout and styling of the "local battle guest" dialog to improve its structure and user experience. The main changes include switching from a flexbox to a CSS grid layout, introducing new content and description sections, and adjusting the input field's width for better responsiveness.

**Layout and Structure Improvements:**

* Changed the dialog's layout from a flexbox (`flex-direction: row`) to a CSS grid for better alignment and responsiveness. Added a new `.local-battle-guest__content` container to organize the description, password input, and battle start button. [[1]](diffhunk://#diff-d63a0e12c948f61be880aaf2add5e368ffb216b06267d1126b47ced7982430d5L30-L33) [[2]](diffhunk://#diff-d63a0e12c948f61be880aaf2add5e368ffb216b06267d1126b47ced7982430d5R42-R71)
* Added a `.local-battle-guest__description` section with a message and a colored arrow to guide the user, improving clarity and visual appeal. [[1]](diffhunk://#diff-53b98ace8bf0f44d7ad4a677f2954375a1a064949760aec2541838929bb1eb91R8-R19) [[2]](diffhunk://#diff-d63a0e12c948f61be880aaf2add5e368ffb216b06267d1126b47ced7982430d5R42-R71)

**Styling Adjustments:**

* Reduced the width of the password input (`.local-battle-guest__password`) for better fit within the new grid layout.
* Added grid area assignments to `.local-battle-guest__password` and `.local-battle-guest__battle-start` for precise placement within the grid.

**Template Update:**

* Updated the dialog's HTML template to include the new content and description elements, ensuring the structure matches the new CSS grid layout.