### PR TITLE
あいことば対戦でパスワード入力を間違えた時に直前の値を表示するようにした

### DIFF
--- a/src/css/local-battle-guest.css
+++ b/src/css/local-battle-guest.css
@@ -83,13 +83,14 @@
   grid-area: matching-failed;
   display: grid;
   place-items: center;
+  font-weight: bold;
   font-size: calc(var(--responsive-font-size) * 1.3);
   min-width: calc(var(--responsive-font-size) * 9);
   min-height: calc(var(--responsive-font-size) * 2);
-  background-color: #2e8b57;
-  border-left: #006400 solid thick;
+  background-color: #c9171e;
+  border-left: #800b23 solid thick;
   box-sizing: border-box;
-  padding: calc(var(--responsive-font-size) * 0.3) 0;
+  padding: calc(var(--responsive-font-size) * 0.5) 0;
   margin-top: calc(var(--responsive-font-size) * 0.5);
   /* opacity: 0; */
 }

--- a/src/css/local-battle-guest.css
+++ b/src/css/local-battle-guest.css
@@ -87,8 +87,8 @@
   font-size: calc(var(--responsive-font-size) * 1.3);
   min-width: calc(var(--responsive-font-size) * 9);
   min-height: calc(var(--responsive-font-size) * 2);
-  background-color: #c9171e;
-  border-left: #800b23 solid thick;
+  background-color: #d7003a;
+  border-left: #eebbcb solid thick;
   box-sizing: border-box;
   padding: calc(var(--responsive-font-size) * 0.5) 0;
   margin-top: calc(var(--responsive-font-size) * 0.5);

--- a/src/css/local-battle-guest.css
+++ b/src/css/local-battle-guest.css
@@ -42,8 +42,9 @@
 .local-battle-guest__content {
   display: grid;
   grid-template:
-    "description description" auto
-    "password battle-start" auto / auto auto;
+    "description     description" auto
+    "password        battle-start" auto
+    "matching-failed matching-failed" auto / auto auto;
   gap: calc(var(--responsive-font-size) * 0.5);
 }
 
@@ -76,4 +77,19 @@
   border: var(--button-border);
   height: calc(var(--responsive-font-size) * 3);
   min-width: calc(var(--responsive-font-size) * 12);
+}
+
+.local-battle-guest__matching-failed {
+  grid-area: matching-failed;
+  display: grid;
+  place-items: center;
+  font-size: calc(var(--responsive-font-size) * 1.3);
+  min-width: calc(var(--responsive-font-size) * 9);
+  min-height: calc(var(--responsive-font-size) * 2);
+  background-color: #2e8b57;
+  border-left: #006400 solid thick;
+  box-sizing: border-box;
+  padding: calc(var(--responsive-font-size) * 0.3) 0;
+  margin-top: calc(var(--responsive-font-size) * 0.5);
+  /* opacity: 0; */
 }

--- a/src/css/local-battle-guest.css
+++ b/src/css/local-battle-guest.css
@@ -88,9 +88,9 @@
   min-width: calc(var(--responsive-font-size) * 9);
   min-height: calc(var(--responsive-font-size) * 2);
   background-color: #d7003a;
-  border-left: #eebbcb solid thick;
+  border-left: #f09199 solid thick;
   box-sizing: border-box;
   padding: calc(var(--responsive-font-size) * 0.5) 0;
   margin-top: calc(var(--responsive-font-size) * 0.5);
-  /* opacity: 0; */
+  opacity: 0;
 }

--- a/src/js/dom-dialogs/local-battle-guest/dom/extract-element.ts
+++ b/src/js/dom-dialogs/local-battle-guest/dom/extract-element.ts
@@ -26,3 +26,12 @@ export const extractPassword = (root: HTMLElement): HTMLInputElement => {
 export const extractBattleStart = (root: HTMLElement): HTMLElement =>
   root.querySelector(`[data-id="battle-start"]`) ??
   document.createElement("div");
+
+/**
+ * マッチング失敗の表示を抽出する
+ * @param root ルートHTML要素
+ * @returns 抽出したもの
+ */
+export const extractMatchingFailed = (root: HTMLElement): HTMLElement =>
+  root.querySelector(`[data-id="matching-failed"]`) ??
+  document.createElement("div");

--- a/src/js/dom-dialogs/local-battle-guest/dom/root-inner-html.hbs
+++ b/src/js/dom-dialogs/local-battle-guest/dom/root-inner-html.hbs
@@ -20,6 +20,9 @@
       class="{{ROOT_CLASS}}__battle-start"
       data-id="battle-start"
     >バトルスタート</button>
-    <div class="{{ROOT_CLASS}}__matching-failed">マッチングに失敗しました</div>
+    <div
+      class="{{ROOT_CLASS}}__matching-failed"
+      data-id="matching-failed"
+    >マッチングに失敗しました</div>
   </div>
 </div>

--- a/src/js/dom-dialogs/local-battle-guest/dom/root-inner-html.hbs
+++ b/src/js/dom-dialogs/local-battle-guest/dom/root-inner-html.hbs
@@ -10,7 +10,12 @@
       あいことばを入れてね
       <span class="{{ROOT_CLASS}}__arrow">⬇</span>
     </div>
-    <input class="{{ROOT_CLASS}}__password" type="text" data-id="password" />
+    <input
+      class="{{ROOT_CLASS}}__password"
+      type="text"
+      data-id="password"
+      value="{{initialRoomId}}"
+    />
     <button
       class="{{ROOT_CLASS}}__battle-start"
       data-id="battle-start"

--- a/src/js/dom-dialogs/local-battle-guest/dom/root-inner-html.hbs
+++ b/src/js/dom-dialogs/local-battle-guest/dom/root-inner-html.hbs
@@ -20,5 +20,6 @@
       class="{{ROOT_CLASS}}__battle-start"
       data-id="battle-start"
     >バトルスタート</button>
+    <div class="{{ROOT_CLASS}}__matching-failed">マッチングに失敗しました</div>
   </div>
 </div>

--- a/src/js/dom-dialogs/local-battle-guest/dom/root-inner-html.hbs
+++ b/src/js/dom-dialogs/local-battle-guest/dom/root-inner-html.hbs
@@ -23,6 +23,6 @@
     <div
       class="{{ROOT_CLASS}}__matching-failed"
       data-id="matching-failed"
-    >マッチングに失敗しました</div>
+    >マッチング失敗</div>
   </div>
 </div>

--- a/src/js/dom-dialogs/local-battle-guest/dom/root-inner-html.ts
+++ b/src/js/dom-dialogs/local-battle-guest/dom/root-inner-html.ts
@@ -4,7 +4,10 @@ import { ROOT_CLASS } from "./class-name";
 import template from "./root-inner-html.hbs";
 
 /** ルートHTML要素のinnerHTMLのオプション */
-export type RootInnerHTMLOptions = ResourcesContainer;
+export type RootInnerHTMLOptions = ResourcesContainer & {
+  /** ルームIDの初期値 */
+  initialRoomId?: string;
+};
 
 /**
  * ルートHTML要素のinnerHTMLを生成する
@@ -12,10 +15,12 @@ export type RootInnerHTMLOptions = ResourcesContainer;
  */
 export const rootInnerHTML = (options: RootInnerHTMLOptions) => {
   const { resources } = options;
+  const initialRoomId = options.initialRoomId ?? "";
   const closerPath =
     resources.paths.find((p) => p.id === PathIds.CLOSER)?.path ?? "";
   return template({
     ROOT_CLASS,
     closerPath,
+    initialRoomId,
   });
 };

--- a/src/js/dom-dialogs/local-battle-guest/index.ts
+++ b/src/js/dom-dialogs/local-battle-guest/index.ts
@@ -6,8 +6,8 @@ import {
   createLocalBattleGuestDialogProps,
   CreateLocalBattleGuestDialogPropsOptions,
 } from "./procedure/create-local-battle-guest-dialog-props";
-import { BattleStartPayload, LocalBattleGuestDialogProps } from "./props";
 import { flashFailedMessage } from "./procedure/flash-failed-message";
+import { BattleStartPayload, LocalBattleGuestDialogProps } from "./props";
 
 /** ローカル対戦ゲストのダイアログのオプション */
 export type LocalBattleGuestDialogOptions =

--- a/src/js/dom-dialogs/local-battle-guest/index.ts
+++ b/src/js/dom-dialogs/local-battle-guest/index.ts
@@ -7,6 +7,7 @@ import {
   CreateLocalBattleGuestDialogPropsOptions,
 } from "./procedure/create-local-battle-guest-dialog-props";
 import { BattleStartPayload, LocalBattleGuestDialogProps } from "./props";
+import { flashFailedMessage } from "./procedure/flash-failed-message";
 
 /** ローカル対戦ゲストのダイアログのオプション */
 export type LocalBattleGuestDialogOptions =
@@ -54,5 +55,13 @@ export class LocalBattleGuestDialog implements DOMDialog {
    */
   notifyDialogClosed(): Observable<void> {
     return this.#props.dialogClosedSubject;
+  }
+
+  /**
+   * 失敗メッセージをフラッシュ表示する
+   * @returns アニメーション
+   */
+  flushFailedMessage(): Promise<void> {
+    return flashFailedMessage(this.#props);
   }
 }

--- a/src/js/dom-dialogs/local-battle-guest/index.ts
+++ b/src/js/dom-dialogs/local-battle-guest/index.ts
@@ -61,7 +61,7 @@ export class LocalBattleGuestDialog implements DOMDialog {
    * 失敗メッセージをフラッシュ表示する
    * @returns アニメーション
    */
-  flushFailedMessage(): Promise<void> {
+  flashFailedMessage(): Promise<void> {
     return flashFailedMessage(this.#props);
   }
 }

--- a/src/js/dom-dialogs/local-battle-guest/procedure/create-local-battle-guest-dialog-props.ts
+++ b/src/js/dom-dialogs/local-battle-guest/procedure/create-local-battle-guest-dialog-props.ts
@@ -8,6 +8,7 @@ import { ROOT_CLASS } from "../dom/class-name";
 import {
   extractBattleStart,
   extractCloser,
+  extractMatchingFailed,
   extractPassword,
 } from "../dom/extract-element";
 import { rootInnerHTML, RootInnerHTMLOptions } from "../dom/root-inner-html";
@@ -36,6 +37,8 @@ export const createLocalBattleGuestDialogProps = (
 
   const battleStartButton = extractBattleStart(root);
 
+  const matchingFailed = extractMatchingFailed(root);
+
   const battleStartSound =
     resources.sounds.find((s) => s.id === SOUND_IDS.PUSH_BUTTON) ??
     createEmptySoundResource();
@@ -53,6 +56,7 @@ export const createLocalBattleGuestDialogProps = (
     closer,
     password,
     battleStartButton,
+    matchingFailed,
 
     se,
     battleStartSound,

--- a/src/js/dom-dialogs/local-battle-guest/procedure/flash-failed-message.ts
+++ b/src/js/dom-dialogs/local-battle-guest/procedure/flash-failed-message.ts
@@ -1,0 +1,25 @@
+import { waitFinishAnimation } from "../../../dom/wait-finish-animation";
+import { LocalBattleGuestDialogProps } from "../props";
+
+/**
+ * マッチング失敗メッセージをフラッシュする
+ * @param props プロパティ
+ * @returns アニメーションが完了したら発火するPromise
+ */
+export async function flashFailedMessage(props: LocalBattleGuestDialogProps) {
+  const { matchingFailed } = props;
+  const animation = matchingFailed.animate(
+    [
+      { transform: "translate(0, -100%)" },
+      { transform: "translate(0, -120%)", opacity: 1, offset: 0.2 },
+      { opacity: 1, offset: 0.8 },
+      { transform: "translate(0, -120%)", opacity: 0 },
+    ],
+    {
+      duration: 1500,
+      fill: "forwards",
+      easing: "linear",
+    },
+  );
+  await waitFinishAnimation(animation);
+}

--- a/src/js/dom-dialogs/local-battle-guest/procedure/flash-failed-message.ts
+++ b/src/js/dom-dialogs/local-battle-guest/procedure/flash-failed-message.ts
@@ -10,13 +10,13 @@ export async function flashFailedMessage(props: LocalBattleGuestDialogProps) {
   const { matchingFailed } = props;
   const animation = matchingFailed.animate(
     [
-      { transform: "translate(0, -100%)" },
-      { transform: "translate(0, -120%)", opacity: 1, offset: 0.2 },
+      { transform: "translate(0, 40%)", opacity: 0 },
+      { transform: "translate(0, 0)", opacity: 1, offset: 0.2 },
       { opacity: 1, offset: 0.8 },
-      { transform: "translate(0, -120%)", opacity: 0 },
+      { transform: "translate(0, 0)", opacity: 0 },
     ],
     {
-      duration: 1500,
+      duration: 2000,
       fill: "forwards",
       easing: "linear",
     },

--- a/src/js/dom-dialogs/local-battle-guest/props.ts
+++ b/src/js/dom-dialogs/local-battle-guest/props.ts
@@ -20,6 +20,8 @@ export type LocalBattleGuestDialogProps = SEPlayerContainer & {
   password: HTMLInputElement;
   /** バトルスタートボタン */
   battleStartButton: HTMLElement;
+  /** マッチング失敗のメッセージ */
+  matchingFailed: HTMLElement;
 
   /** バトルスタートボタンを押したときのサウンド */
   battleStartSound: SoundResource;

--- a/src/js/game/game-procedure/on-game-action/on-local-battle-entry.ts
+++ b/src/js/game/game-procedure/on-game-action/on-local-battle-entry.ts
@@ -1,11 +1,11 @@
+import { LocalBattleGuestDialog } from "../../../dom-dialogs/local-battle-guest";
 import { MatchingDialog } from "../../../dom-dialogs/matching/matching-dialog";
-import { RejectPrivateMatchEntryDialog } from "../../../dom-dialogs/reject-private-match-entry";
 import { LocalBattleEntry } from "../../game-actions/local-battle-entry";
 import { GameProps } from "../../game-props";
 import { disconnectConnection } from "../disconnect-connection";
 import { startLocalBattle } from "../start-local-battle";
+import { switchLocalBattleGuestDialog } from "../switch-dialog/switch-local-battle-guest-dialog";
 import { switchMatchingDialog } from "../switch-dialog/switch-matching-dialog";
-import { switchRejectPrivateMatchEntryDialog } from "../switch-dialog/switch-reject-private-match-entry-dialog";
 
 /**
  * ゲストがローカル対戦にエントリーする
@@ -38,9 +38,11 @@ export const onLocalBattleEntry = async (options: {
     pilotId,
   });
   if (!battle) {
-    // TODO 専用ダイアログを作る
-    //const dialog = new RejectPrivateMatchEntryDialog(props);
-    //switchRejectPrivateMatchEntryDialog(props, dialog);
+    const dialog = new LocalBattleGuestDialog({
+      ...props,
+      initialRoomId: roomID,
+    });
+    switchLocalBattleGuestDialog(props, dialog);
     return;
   }
 

--- a/src/js/game/game-procedure/on-game-action/on-local-battle-entry.ts
+++ b/src/js/game/game-procedure/on-game-action/on-local-battle-entry.ts
@@ -43,7 +43,7 @@ export const onLocalBattleEntry = async (options: {
       initialRoomId: roomID,
     });
     switchLocalBattleGuestDialog(props, dialog);
-    dialog.flushFailedMessage();
+    dialog.flashFailedMessage();
     return;
   }
 

--- a/src/js/game/game-procedure/on-game-action/on-local-battle-entry.ts
+++ b/src/js/game/game-procedure/on-game-action/on-local-battle-entry.ts
@@ -43,6 +43,7 @@ export const onLocalBattleEntry = async (options: {
       initialRoomId: roomID,
     });
     switchLocalBattleGuestDialog(props, dialog);
+    dialog.flushFailedMessage();
     return;
   }
 

--- a/src/js/game/game-procedure/on-game-action/on-local-battle-entry.ts
+++ b/src/js/game/game-procedure/on-game-action/on-local-battle-entry.ts
@@ -39,8 +39,8 @@ export const onLocalBattleEntry = async (options: {
   });
   if (!battle) {
     // TODO 専用ダイアログを作る
-    const dialog = new RejectPrivateMatchEntryDialog(props);
-    switchRejectPrivateMatchEntryDialog(props, dialog);
+    //const dialog = new RejectPrivateMatchEntryDialog(props);
+    //switchRejectPrivateMatchEntryDialog(props, dialog);
     return;
   }
 

--- a/stories/local-battle-guest-dialog.stories.ts
+++ b/stories/local-battle-guest-dialog.stories.ts
@@ -16,3 +16,19 @@ export const dialog = domStub((options) => {
   });
   return dialog.getRootHTMLElement();
 });
+
+/** 失敗メッセージ表示 */
+export const failed = domStub((options) => {
+  const dialog = new LocalBattleGuestDialog({
+    ...options,
+    initialRoomId: "ないよそん",
+  });
+  dialog.notifyBattleStart().subscribe((payload) => {
+    console.log(`battle start ${payload.password}`);
+  });
+  dialog.notifyDialogClosed().subscribe(() => {
+    console.log("dialog closed");
+  });
+  dialog.flushFailedMessage();
+  return dialog.getRootHTMLElement();
+});

--- a/stories/local-battle-guest-dialog.stories.ts
+++ b/stories/local-battle-guest-dialog.stories.ts
@@ -29,6 +29,6 @@ export const failed = domStub((options) => {
   dialog.notifyDialogClosed().subscribe(() => {
     console.log("dialog closed");
   });
-  dialog.flushFailedMessage();
+  dialog.flashFailedMessage();
   return dialog.getRootHTMLElement();
 });


### PR DESCRIPTION
This pull request introduces a new "matching failed" message to the local battle guest dialog, improving user feedback when a match cannot be established. The main changes include updating the dialog's UI and logic to support this message, providing a flashing animation for visibility, and refactoring related code to integrate the new feature.

**UI and Styling Enhancements:**
- Added a `.local-battle-guest__matching-failed` element to the dialog's HTML template and updated the CSS grid layout to accommodate the new message area. The message is styled with bold text, a red background, and is initially hidden via opacity. [[1]](diffhunk://#diff-53b98ace8bf0f44d7ad4a677f2954375a1a064949760aec2541838929bb1eb91L13-R26) [[2]](diffhunk://#diff-d63a0e12c948f61be880aaf2add5e368ffb216b06267d1126b47ced7982430d5L46-R47) [[3]](diffhunk://#diff-d63a0e12c948f61be880aaf2add5e368ffb216b06267d1126b47ced7982430d5R81-R96)

**Dialog Logic and Props:**
- Extended the dialog's props and extraction utilities to include the new "matching failed" element, ensuring it can be accessed and manipulated by dialog logic. [[1]](diffhunk://#diff-7fe9816714ba6f5770169b87aa17c13caa3a218a266af7d4c6fa5e57bd89cdffR23-R24) [[2]](diffhunk://#diff-e2bb353cb3b899ba13164f14f28f7c95c2b7124b0e98ec645810ea82870fbc93R11) [[3]](diffhunk://#diff-e2bb353cb3b899ba13164f14f28f7c95c2b7124b0e98ec645810ea82870fbc93R40-R41) [[4]](diffhunk://#diff-e2bb353cb3b899ba13164f14f28f7c95c2b7124b0e98ec645810ea82870fbc93R59) [[5]](diffhunk://#diff-150d34a1e82fd88689cfccc348ccc1c31d4e24d86c8b8415a5a35945be5f446aR29-R37)

**Animation and Feedback:**
- Implemented the `flashFailedMessage` function, which animates the appearance and disappearance of the "matching failed" message, and exposed this as a public method (`flushFailedMessage`) on the dialog class. [[1]](diffhunk://#diff-3af4ea93f1bca35b38a9f5d9dafe04032c0fd097728d1f7f9d9dd7744d61b77aR1-R25) [[2]](diffhunk://#diff-bb236f4cc2d0b9012ff293ccb1e3a32ccff8364b032edf7938c2fbfefea4c54cR9) [[3]](diffhunk://#diff-bb236f4cc2d0b9012ff293ccb1e3a32ccff8364b032edf7938c2fbfefea4c54cR59-R66)

**Integration with Game Procedure:**
- Updated the local battle entry procedure to show the "matching failed" message in the guest dialog when a match fails, replacing the previous usage of a generic rejection dialog. [[1]](diffhunk://#diff-485396838780eaf34716404becd1f31651e0b0d1875e4e42d37e501aa17deca2R1-L8) [[2]](diffhunk://#diff-485396838780eaf34716404becd1f31651e0b0d1875e4e42d37e501aa17deca2L41-R46)

**Storybook/Testing:**
- Added a Storybook story to demonstrate and test the "matching failed" message.