### PR TITLE
feat: マッチング失敗メッセージの色とスタイルを更新

### DIFF
--- a/src/css/local-battle-guest.css
+++ b/src/css/local-battle-guest.css
@@ -80,6 +80,9 @@
 }
 
 .local-battle-guest__matching-failed {
+  --main-color: #b22222;
+  --sub-color: #f6bfbc;
+
   grid-area: matching-failed;
   display: grid;
   place-items: center;
@@ -87,8 +90,9 @@
   font-size: calc(var(--responsive-font-size) * 1.3);
   min-width: calc(var(--responsive-font-size) * 9);
   min-height: calc(var(--responsive-font-size) * 2);
-  background-color: #d7003a;
-  border-left: #f09199 solid thick;
+  color: var(--main-color);
+  background-color: var(--sub-color);
+  border-left: var(--main-color) solid thick;
   box-sizing: border-box;
   padding: calc(var(--responsive-font-size) * 0.5) 0;
   margin-top: calc(var(--responsive-font-size) * 0.5);


### PR DESCRIPTION
This pull request makes a small update to the styling of the `.local-battle-guest__matching-failed` element by introducing CSS variables for the main and sub colors, and applying them to the relevant properties for easier customization and improved maintainability.

- Refactored the color and border styles in `.local-battle-guest__matching-failed` to use new CSS variables `--main-color` and `--sub-color`, replacing hardcoded color values. (`src/css/local-battle-guest.css`)