### PR TITLE
Feature/refactor player select dom

### DIFF
--- a/src/js/dom-scenes/player-select/dom/data-ids.ts
+++ b/src/js/dom-scenes/player-select/dom/data-ids.ts
@@ -1,7 +1,0 @@
-/** data-idを集めたもの */
-export type DataIDs = {
-  /** セレクタ領域 */
-  selector: string;
-  /** ワーキング領域 */
-  working: string;
-};

--- a/src/js/dom-scenes/player-select/dom/elements.ts
+++ b/src/js/dom-scenes/player-select/dom/elements.ts
@@ -1,26 +1,15 @@
-import { DataIDs } from "./data-ids";
-
-/** ルート要素の子孫要素 */
-export type Elements = {
-  selector: HTMLElement;
-  working: HTMLElement;
-};
-
 /**
- * ルート要素から子孫要素を抽出する
- * @param root ルート要素
- * @param ids data-idを集めたもの
+ * ワーキング領域を抽出する
+ * @param root ルートHTML要素
  * @returns 抽出結果
  */
-export function extractElements(root: HTMLElement, ids: DataIDs): Elements {
-  const working: HTMLElement =
-    root.querySelector(`[data-id="${ids.working}"]`) ??
-    document.createElement("div");
-  const selector: HTMLElement =
-    root.querySelector(`[data-id="${ids.selector}"]`) ??
-    document.createElement("div");
-  return {
-    working,
-    selector,
-  };
-}
+export const extractWorking = (root: HTMLElement): HTMLElement =>
+  root.querySelector(`[data-id="working"]`) ?? document.createElement("div");
+
+/**
+ * セレクター領域を抽出する
+ * @param root ルートHTML要素
+ * @returns 抽出結果
+ */
+export const extractSelector = (root: HTMLElement): HTMLElement =>
+  root.querySelector(`[data-id="selector"]`) ?? document.createElement("div");

--- a/src/js/dom-scenes/player-select/dom/root-inner-html.hbs
+++ b/src/js/dom-scenes/player-select/dom/root-inner-html.hbs
@@ -1,0 +1,2 @@
+<div class="player-select__working" data-id="{{ids.working}}"></div>
+<div class="player-select__selector" data-id="{{ids.selector}}"></div>

--- a/src/js/dom-scenes/player-select/dom/root-inner-html.hbs
+++ b/src/js/dom-scenes/player-select/dom/root-inner-html.hbs
@@ -1,2 +1,2 @@
-<div class="player-select__working" data-id="{{ids.working}}"></div>
-<div class="player-select__selector" data-id="{{ids.selector}}"></div>
+<div class="player-select__working" data-id="working"></div>
+<div class="player-select__selector" data-id="selector"></div>

--- a/src/js/dom-scenes/player-select/dom/root-inner-html.ts
+++ b/src/js/dom-scenes/player-select/dom/root-inner-html.ts
@@ -1,11 +1,9 @@
-import { DataIDs } from "./data-ids";
 import template from "./root-inner-html.hbs";
 
 /**
  * ルート要素のinnerHTML
- * @param ids data-idを集めたもの
  * @returns innerHTML
  */
-export function rootInnerHTML(ids: DataIDs): string {
-  return template({ ids });
+export function rootInnerHTML(): string {
+  return template({});
 }

--- a/src/js/dom-scenes/player-select/dom/root-inner-html.ts
+++ b/src/js/dom-scenes/player-select/dom/root-inner-html.ts
@@ -1,14 +1,11 @@
 import { DataIDs } from "./data-ids";
+import template from "./root-inner-html.hbs";
 
 /**
  * ルート要素のinnerHTML
- *
  * @param ids data-idを集めたもの
  * @returns innerHTML
  */
 export function rootInnerHTML(ids: DataIDs): string {
-  return `
-    <div class="player-select__working" data-id="${ids.working}"></div>
-    <div class="player-select__selector" data-id="${ids.selector}"></div>
-  `;
+  return template({ ids });
 }

--- a/src/js/dom-scenes/player-select/procedures/create-player-select-props.ts
+++ b/src/js/dom-scenes/player-select/procedures/create-player-select-props.ts
@@ -6,7 +6,7 @@ import { SEPlayerContainer } from "../../../se/se-player";
 import { domUuid } from "../../../uuid/dom-uuid";
 import { ArmdozerBustShotContainer } from "../armdozer-bust-shot";
 import { ArmdozerSelector } from "../armdozer-selector";
-import { extractElements } from "../dom/elements";
+import { extractSelector, extractWorking } from "../dom/elements";
 import { rootInnerHTML } from "../dom/root-inner-html";
 import { PilotBustShotContainer } from "../pilot-bust-shot";
 import { PilotSelector } from "../pilot-selector";
@@ -44,27 +44,29 @@ export function createPlayerSelectProps(
   root.className = "player-select";
   root.innerHTML = rootInnerHTML(dataIDs);
 
-  const elements = extractElements(root, dataIDs);
+  //const elements = extractElements(root, dataIDs);
+  const working = extractWorking(root);
+  const selector = extractSelector(root);
 
   const armdozerBustShot = new ArmdozerBustShotContainer(
     resources,
     armdozerIds,
     armdozerId,
   );
-  elements.working.appendChild(armdozerBustShot.getRootHTMLElement());
+  working.appendChild(armdozerBustShot.getRootHTMLElement());
   const pilotBustShot = new PilotBustShotContainer(
     resources,
     pilotIds,
     pilotId,
   );
   pilotBustShot.hidden();
-  elements.working.appendChild(pilotBustShot.getRootHTMLElement());
+  working.appendChild(pilotBustShot.getRootHTMLElement());
 
   const armdozerSelector = new ArmdozerSelector({
     ...params,
     initialArmdozerId: armdozerId,
   });
-  elements.selector.appendChild(armdozerSelector.getRootHTMLElement());
+  selector.appendChild(armdozerSelector.getRootHTMLElement());
 
   const pilotSelector = new PilotSelector({
     ...params,
@@ -72,7 +74,7 @@ export function createPlayerSelectProps(
     initialPilotId: pilotId,
   });
   pilotSelector.hidden();
-  elements.selector.appendChild(pilotSelector.getRootHTMLElement());
+  selector.appendChild(pilotSelector.getRootHTMLElement());
 
   return {
     root,

--- a/src/js/dom-scenes/player-select/procedures/create-player-select-props.ts
+++ b/src/js/dom-scenes/player-select/procedures/create-player-select-props.ts
@@ -7,7 +7,7 @@ import { domUuid } from "../../../uuid/dom-uuid";
 import { ArmdozerBustShotContainer } from "../armdozer-bust-shot";
 import { ArmdozerSelector } from "../armdozer-selector";
 import { extractElements } from "../dom/elements";
-import { rootInnerHTML } from "../dom/root-innrt-html";
+import { rootInnerHTML } from "../dom/root-inner-html";
 import { PilotBustShotContainer } from "../pilot-bust-shot";
 import { PilotSelector } from "../pilot-selector";
 import { PlayerDecide } from "../player-decide";

--- a/src/js/dom-scenes/player-select/procedures/create-player-select-props.ts
+++ b/src/js/dom-scenes/player-select/procedures/create-player-select-props.ts
@@ -3,7 +3,6 @@ import { Subject } from "rxjs";
 
 import { ResourcesContainer } from "../../../resource";
 import { SEPlayerContainer } from "../../../se/se-player";
-import { domUuid } from "../../../uuid/dom-uuid";
 import { ArmdozerBustShotContainer } from "../armdozer-bust-shot";
 import { ArmdozerSelector } from "../armdozer-selector";
 import { extractSelector, extractWorking } from "../dom/elements";
@@ -35,16 +34,11 @@ export function createPlayerSelectProps(
   const pilotId = PilotIds.SHINYA;
   const playerDecide = new Subject<PlayerDecide>();
   const prev = new Subject<void>();
-  const dataIDs = {
-    selector: domUuid(),
-    working: domUuid(),
-  };
 
   const root = document.createElement("div");
   root.className = "player-select";
-  root.innerHTML = rootInnerHTML(dataIDs);
+  root.innerHTML = rootInnerHTML();
 
-  //const elements = extractElements(root, dataIDs);
   const working = extractWorking(root);
   const selector = extractSelector(root);
 


### PR DESCRIPTION
This pull request refactors how DOM elements are extracted and initialized in the player select scene, making the codebase more modular and maintainable. The main changes involve splitting the element extraction logic into smaller functions, updating template usage, and fixing a filename typo.

**Refactoring and modularization:**

* Split the `extractElements` function in `elements.ts` into two simpler functions: `extractWorking` and `extractSelector`, each responsible for extracting a single DOM element. The old `Elements` type and function were removed.
* Updated `create-player-select-props.ts` to use the new `extractWorking` and `extractSelector` functions instead of the old `extractElements` function. [[1]](diffhunk://#diff-b89c96e3ae4461e7124256a4cd629664be4f4046ada5c109f2342cab5014f8c5L9-R10) [[2]](diffhunk://#diff-b89c96e3ae4461e7124256a4cd629664be4f4046ada5c109f2342cab5014f8c5L47-R77)

**Template improvements:**

* Added a Handlebars template file `root-inner-html.hbs` to define the root HTML structure for the player select scene, and updated the code to use this template for generating inner HTML. [[1]](diffhunk://#diff-c0edfe3f23f50069842cf2105c2e687626f83552ceffb8e94ec399e2890f37f4R1-R2) [[2]](diffhunk://#diff-120b805e1e090f507711bd7ceaaec9ecf1fd3a530672ad1c7720004a6ad313d7R2-R10)

**File organization and typo fix:**

* Renamed the file `root-innrt-html.ts` to the correct `root-inner-html.ts` to fix a typo and updated all imports accordingly. [[1]](diffhunk://#diff-120b805e1e090f507711bd7ceaaec9ecf1fd3a530672ad1c7720004a6ad313d7R2-R10) [[2]](diffhunk://#diff-b89c96e3ae4461e7124256a4cd629664be4f4046ada5c109f2342cab5014f8c5L9-R10)