### PR TITLE
あいことば対戦のモードを表示するようにした

### DIFF
--- a/src/css/player-select.css
+++ b/src/css/player-select.css
@@ -40,6 +40,10 @@
   z-index: 2;
 }
 
+.player-select__battle-mode--invisible {
+  display: none;
+}
+
 .player-select__working {
   z-index: var(--working-zindex);
   position: relative;

--- a/src/css/player-select.css
+++ b/src/css/player-select.css
@@ -32,7 +32,7 @@
   position: absolute;
   right: var(--screen-padding-right);
   border-radius: var(--button-border-radius);
-  border: 1px solid #e6e3e1;
+  border: var(--dialog-border);
   background-color: var(--sub-button-background-color);
   box-shadow: var(--sub-button-box-shadow);
   color: var(--button-font-color);

--- a/src/css/player-select.css
+++ b/src/css/player-select.css
@@ -27,6 +27,19 @@
   }
 }
 
+.player-select__battle-mode {
+  font-size: var(--responsive-font-size);
+  position: absolute;
+  right: var(--screen-padding-right);
+  border-radius: var(--button-border-radius);
+  border: 1px solid #e6e3e1;
+  background-color: var(--sub-button-background-color);
+  box-shadow: var(--sub-button-box-shadow);
+  color: var(--button-font-color);
+  padding: calc(var(--responsive-font-size) * 0.5);
+  z-index: 2;
+}
+
 .player-select__working {
   z-index: var(--working-zindex);
   position: relative;

--- a/src/css/player-select.css
+++ b/src/css/player-select.css
@@ -7,6 +7,7 @@
     --selector-zindex: 2;
     --check-width: 6vw;
 
+    position: relative;
     display: flex;
     flex-direction: column;
     width: 100vw;

--- a/src/js/dom-scenes/player-select/dom/root-inner-html.hbs
+++ b/src/js/dom-scenes/player-select/dom/root-inner-html.hbs
@@ -1,2 +1,3 @@
+<div class="player-select__battle-mode">🔑あいことばを作る</div>
 <div class="player-select__working" data-id="working"></div>
 <div class="player-select__selector" data-id="selector"></div>

--- a/src/js/dom-scenes/player-select/dom/root-inner-html.hbs
+++ b/src/js/dom-scenes/player-select/dom/root-inner-html.hbs
@@ -1,3 +1,3 @@
-<div class="player-select__battle-mode">🔑あいことばを作る</div>
+<div class="player-select__battle-mode">{{battleMode}}</div>
 <div class="player-select__working" data-id="working"></div>
 <div class="player-select__selector" data-id="selector"></div>

--- a/src/js/dom-scenes/player-select/dom/root-inner-html.hbs
+++ b/src/js/dom-scenes/player-select/dom/root-inner-html.hbs
@@ -1,3 +1,3 @@
-<div class="player-select__battle-mode">{{battleMode}}</div>
+<div class="{{battleModeClass}}">{{battleModeValue}}</div>
 <div class="player-select__working" data-id="working"></div>
 <div class="player-select__selector" data-id="selector"></div>

--- a/src/js/dom-scenes/player-select/dom/root-inner-html.ts
+++ b/src/js/dom-scenes/player-select/dom/root-inner-html.ts
@@ -12,6 +12,9 @@ export type RootInnerHTMLOptions = {
  * @returns innerHTML
  */
 export function rootInnerHTML(options: RootInnerHTMLOptions): string {
-  const battleMode = options?.battleMode ?? "";
-  return template({ battleMode });
+  const battleModeClass = options.battleMode
+    ? "player-select__battle-mode"
+    : "player-select__battle-mode--invisible";
+  const battleModeValue = options?.battleMode ?? "";
+  return template({ battleModeClass, battleModeValue });
 }

--- a/src/js/dom-scenes/player-select/dom/root-inner-html.ts
+++ b/src/js/dom-scenes/player-select/dom/root-inner-html.ts
@@ -8,7 +8,7 @@ export type RootInnerHTMLOptions = {
 
 /**
  * ルート要素のinnerHTML
- * @param battleMode 戦闘モード
+ * @param options オプション
  * @returns innerHTML
  */
 export function rootInnerHTML(options: RootInnerHTMLOptions): string {

--- a/src/js/dom-scenes/player-select/dom/root-inner-html.ts
+++ b/src/js/dom-scenes/player-select/dom/root-inner-html.ts
@@ -1,9 +1,17 @@
 import template from "./root-inner-html.hbs";
 
+/** ルート要素innerHTML生成オプション */
+export type RootInnerHTMLOptions = {
+  /** 戦闘モード */
+  battleMode?: string;
+};
+
 /**
  * ルート要素のinnerHTML
+ * @param battleMode 戦闘モード
  * @returns innerHTML
  */
-export function rootInnerHTML(): string {
-  return template({});
+export function rootInnerHTML(options: RootInnerHTMLOptions): string {
+  const battleMode = options?.battleMode ?? "";
+  return template({ battleMode });
 }

--- a/src/js/dom-scenes/player-select/procedures/create-player-select-props.ts
+++ b/src/js/dom-scenes/player-select/procedures/create-player-select-props.ts
@@ -6,7 +6,7 @@ import { SEPlayerContainer } from "../../../se/se-player";
 import { ArmdozerBustShotContainer } from "../armdozer-bust-shot";
 import { ArmdozerSelector } from "../armdozer-selector";
 import { extractSelector, extractWorking } from "../dom/elements";
-import { rootInnerHTML } from "../dom/root-inner-html";
+import { rootInnerHTML, RootInnerHTMLOptions } from "../dom/root-inner-html";
 import { PilotBustShotContainer } from "../pilot-bust-shot";
 import { PilotSelector } from "../pilot-selector";
 import { PlayerDecide } from "../player-decide";
@@ -14,6 +14,7 @@ import { PlayerSelectProps } from "../props";
 
 /** 生成パラメータ */
 export type CreatePlayerSelectPropsParams = ResourcesContainer &
+  RootInnerHTMLOptions &
   SEPlayerContainer & {
     /** プレイアブルなアームドーザのID */
     armdozerIds: ArmdozerId[];
@@ -37,7 +38,7 @@ export function createPlayerSelectProps(
 
   const root = document.createElement("div");
   root.className = "player-select";
-  root.innerHTML = rootInnerHTML();
+  root.innerHTML = rootInnerHTML(params);
 
   const working = extractWorking(root);
   const selector = extractSelector(root);

--- a/src/js/game/game-procedure/bind-player-select-according-to-config.ts
+++ b/src/js/game/game-procedure/bind-player-select-according-to-config.ts
@@ -15,6 +15,8 @@ type SceneBinderParams = GameProps & {
   armdozerIds: ArmdozerId[];
   /** 選択可能なパイロットID */
   pilotIds: PilotId[];
+  /** 戦闘モード（通常選択画面でのみ有効） */
+  battleMode?: string;
 };
 
 /**
@@ -56,16 +58,19 @@ const binders: { [key in PlayerSelectorType]: SceneBinder } = {
  * 設定値に応じたプレイヤー選択画面をバインドする
  * @param props ゲームプロパティ
  * @param playerSelectorType ロボ、パイロット選択タイプ
+ * @param battleMode 戦闘モード（通常選択画面でのみ有効）
  * @returns 画面の素材読み込みまで完了したら発火するPromise
  */
 export async function bindPlayerSelectAccordingToConfig(
   props: GameProps,
   playerSelectorType: PlayerSelectorType,
+  battleMode?: string,
 ): Promise<void> {
   const binder = binders[playerSelectorType] ?? binders.open;
   await binder({
     ...props,
     armdozerIds: getPlayableArmdozers(props),
     pilotIds: getPlayablePilots(props),
+    battleMode,
   });
 }

--- a/src/js/game/game-procedure/on-game-action/on-local-battle-guest-start.ts
+++ b/src/js/game/game-procedure/on-game-action/on-local-battle-guest-start.ts
@@ -27,7 +27,11 @@ export const onLocalBattleGuestStart = async (options: {
   await props.fader.fadeOut();
   const config = await props.config.load();
   await Promise.race([
-    bindPlayerSelectAccordingToConfig(props, config.playerSelectorType),
+    bindPlayerSelectAccordingToConfig(
+      props,
+      config.playerSelectorType,
+      "🔓あいことばで入る",
+    ),
     waitTime(MAX_LOADING_TIME),
   ]);
   await props.fader.fadeIn();

--- a/src/js/game/game-procedure/on-game-action/on-local-battle-host-start.ts
+++ b/src/js/game/game-procedure/on-game-action/on-local-battle-host-start.ts
@@ -28,7 +28,11 @@ export const onLocalBattleHostStart = async (options: {
   await props.fader.fadeOut();
   const config = await props.config.load();
   await Promise.race([
-    bindPlayerSelectAccordingToConfig(props, config.playerSelectorType),
+    bindPlayerSelectAccordingToConfig(
+      props,
+      config.playerSelectorType,
+      "🔑あいことばを作る",
+    ),
     waitTime(MAX_LOADING_TIME),
   ]);
   await props.fader.fadeIn();

--- a/stories/player-select.stories.ts
+++ b/stories/player-select.stories.ts
@@ -11,36 +11,13 @@ export default {
   title: "player-select",
 };
 
+/** シーン表示 */
 export const scene = domStub((params) => {
   const scene = new PlayerSelect({
     ...params,
     armdozerIds: PlayableArmdozers,
     pilotIds: PlayablePilots,
+    battleMode: "アーケード",
   });
   return scene.getRootHTMLElement();
-});
-
-export const armdozerSelector = domStub((params) => {
-  const armdozerIds = [
-    ArmdozerIds.NEO_LANDOZER,
-    ArmdozerIds.SHIN_BRAVER,
-    ArmdozerIds.WING_DOZER,
-    ArmdozerIds.LIGHTNING_DOZER,
-  ];
-  const component = new ArmdozerSelector({
-    ...params,
-    armdozerIds,
-    initialArmdozerId: ArmdozerIds.SHIN_BRAVER,
-  });
-  return component.getRootHTMLElement();
-});
-
-export const pilotSelector = domStub((params) => {
-  const pilotIds = [PilotIds.SHINYA, PilotIds.GAI];
-  const component = new PilotSelector({
-    ...params,
-    pilotIds,
-    initialPilotId: PilotIds.SHINYA,
-  });
-  return component.getRootHTMLElement();
 });

--- a/stories/player-select.stories.ts
+++ b/stories/player-select.stories.ts
@@ -1,8 +1,4 @@
-import { ArmdozerIds, PilotIds } from "gbraver-burst-core";
-
 import { PlayerSelect } from "../src/js/dom-scenes/player-select";
-import { ArmdozerSelector } from "../src/js/dom-scenes/player-select/armdozer-selector";
-import { PilotSelector } from "../src/js/dom-scenes/player-select/pilot-selector";
 import { PlayableArmdozers } from "../src/js/game/playable-amdozers";
 import { PlayablePilots } from "../src/js/game/playable-pilots";
 import { domStub } from "./stub/dom-stub";
@@ -17,7 +13,17 @@ export const scene = domStub((params) => {
     ...params,
     armdozerIds: PlayableArmdozers,
     pilotIds: PlayablePilots,
-    battleMode: "アーケード",
+  });
+  return scene.getRootHTMLElement();
+});
+
+/** 戦闘モード表示 */
+export const hasBattleMode = domStub((params) => {
+  const scene = new PlayerSelect({
+    ...params,
+    armdozerIds: PlayableArmdozers,
+    pilotIds: PlayablePilots,
+    battleMode: "🔑あいことばを作る",
   });
   return scene.getRootHTMLElement();
 });


### PR DESCRIPTION
This pull request adds support for displaying a "battle mode" indicator on the player selection screen, which can show context-specific messages such as "🔑あいことばを作る" or "🔓あいことばで入る" depending on the game mode. The implementation includes updates to the UI, the data flow, and the relevant procedures to pass and render this new information.

**Battle Mode Indicator Feature:**

* Added a new `battleMode` option to the player select screen, including corresponding CSS styles for visibility and appearance (`player-select__battle-mode`, `player-select__battle-mode--invisible`) in `player-select.css`.
* Updated the player select screen's template and TypeScript logic to accept and render the `battleMode` value, using conditional classes for display (`root-inner-html.hbs`, `root-inner-html.ts`). [[1]](diffhunk://#diff-c0edfe3f23f50069842cf2105c2e687626f83552ceffb8e94ec399e2890f37f4R1) [[2]](diffhunk://#diff-120b805e1e090f507711bd7ceaaec9ecf1fd3a530672ad1c7720004a6ad313d7R3-R19)

**Data Flow & Procedure Updates:**

* Extended the creation parameters and logic for player select props and binders to accept and propagate the `battleMode` option throughout the scene setup (`create-player-select-props.ts`, `bind-player-select-according-to-config.ts`). [[1]](diffhunk://#diff-b89c96e3ae4461e7124256a4cd629664be4f4046ada5c109f2342cab5014f8c5L9-R17) [[2]](diffhunk://#diff-b89c96e3ae4461e7124256a4cd629664be4f4046ada5c109f2342cab5014f8c5L40-R41) [[3]](diffhunk://#diff-99442330b80d160f8e1026402b851900249fb09d7e67fa5e8567d2147a4479e8R18-R19) [[4]](diffhunk://#diff-99442330b80d160f8e1026402b851900249fb09d7e67fa5e8567d2147a4479e8R61-R74)
* Modified local battle host and guest start procedures to set the appropriate `battleMode` string when binding the player select screen (`on-local-battle-host-start.ts`, `on-local-battle-guest-start.ts`). [[1]](diffhunk://#diff-3a7e77a540b0e30c3ec77cf59e1ab70ce1749ca056bce13ca3ea72dc662bf6d8L31-R35) [[2]](diffhunk://#diff-670f551579b7ed0295db847910b34620fc03ee13b494b95dc4fd4c2bede909deL30-R34)

**Storybook / Example Updates:**

* Added a new Storybook story to demonstrate the player select screen with the battle mode indicator, and removed obsolete selector stories for clarity (`player-select.stories.ts`). [[1]](diffhunk://#diff-03ec439fef7370d7267fa915697636b2e9a67142809815705d3368e5f9a155c8L1-L5) [[2]](diffhunk://#diff-03ec439fef7370d7267fa915697636b2e9a67142809815705d3368e5f9a155c8R10) [[3]](diffhunk://#diff-03ec439fef7370d7267fa915697636b2e9a67142809815705d3368e5f9a155c8L23-R28)