### PR TITLE
ダメージ予想のバトルシミュレーターアイコン位置を設定できるようにした

### DIFF
--- a/src/js/game-object/predicated-damage/model/initial-value.ts
+++ b/src/js/game-object/predicated-damage/model/initial-value.ts
@@ -1,14 +1,21 @@
-import { PredicatedDamageModel } from "./predicated-damage-model";
+import {
+  BattleSimulatorIconPosition,
+  PredicatedDamageModel,
+} from "./predicated-damage-model";
 
 /**
  * モデルの初期値を生成する
+ * @param battleSimulatorIconPosition バトルシミュレーターアイコンの位置
  * @returns 生成結果
  */
-export function initialValue(): PredicatedDamageModel {
+export function initialValue(
+  battleSimulatorIconPosition: BattleSimulatorIconPosition,
+): PredicatedDamageModel {
   return {
     damage: 2000,
     opacity: 0,
     shouldPushNotifierStop: true,
+    battleSimulatorIconPosition,
     battleSimulatorIconScale: 1,
   };
 }

--- a/src/js/game-object/predicated-damage/model/predicated-damage-model.ts
+++ b/src/js/game-object/predicated-damage/model/predicated-damage-model.ts
@@ -1,3 +1,6 @@
+/** バトルシミュレーターアイコンの位置 */
+export type BattleSimulatorIconPosition = "right" | "left";
+
 /** ダメージ予想 モデル */
 export type PredicatedDamageModel = {
   /** 表示するダメージ */
@@ -10,6 +13,8 @@ export type PredicatedDamageModel = {
    * バーストボタンが反応しないようにする
    */
   shouldPushNotifierStop: boolean;
+  /** バトルシミュレーターアイコンの位置 */
+  battleSimulatorIconPosition: BattleSimulatorIconPosition;
   /** バトルシミュレーターアイコンのスケール */
   battleSimulatorIconScale: number;
 };

--- a/src/js/game-object/predicated-damage/props/create-predicated-damage-props.ts
+++ b/src/js/game-object/predicated-damage/props/create-predicated-damage-props.ts
@@ -1,5 +1,6 @@
 import { SEPlayerContainer } from "../../../se/se-player";
 import { initialValue } from "../model/initial-value";
+import { BattleSimulatorIconPosition } from "../model/predicated-damage-model";
 import { createPredicatedDamageSounds } from "../sounds/create-status-icon-sounds";
 import {
   PredicatedDamageView,
@@ -9,7 +10,11 @@ import { PredicatedDamageProps } from "./predicated-damage-props";
 
 /** 生成パラメータ */
 export type PredicatedDamagePropsCreatorParams =
-  PredicatedDamageViewConstructParams & SEPlayerContainer;
+  PredicatedDamageViewConstructParams &
+    SEPlayerContainer & {
+      /** バトルシミュレーターアイコンの位置 */
+      battleSimulatorIconPosition: BattleSimulatorIconPosition;
+    };
 
 /**
  * PredicatedDamagePropsを生成する
@@ -19,9 +24,10 @@ export type PredicatedDamagePropsCreatorParams =
 export function createPredicatedDamageProps(
   params: PredicatedDamagePropsCreatorParams,
 ): PredicatedDamageProps {
+  const { battleSimulatorIconPosition } = params;
   return {
     ...params,
-    model: initialValue(),
+    model: initialValue(battleSimulatorIconPosition),
     view: new PredicatedDamageView(params),
     sounds: createPredicatedDamageSounds(params.resources),
     disabled: false,

--- a/src/js/game-object/predicated-damage/view/predicated-damage-view.ts
+++ b/src/js/game-object/predicated-damage/view/predicated-damage-view.ts
@@ -160,14 +160,13 @@ export class PredicatedDamageView {
       sign.animate(10 / MAX_ANIMATION);
     }
 
+    const battleSimulatorIconOffsetX = (intervalCount / 2) * NUMBER_MESH_INTERVAL +
+          BATTLE_SIMULATOR_ICON_SIZE / 2 +
+          NUMBER_TO_ICON_MARGIN;
     const battleSimulatorIconX =
       model.battleSimulatorIconPosition === "right"
-        ? (intervalCount / 2) * NUMBER_MESH_INTERVAL +
-            BATTLE_SIMULATOR_ICON_SIZE / 2 +
-            NUMBER_TO_ICON_MARGIN
-        : -((intervalCount / 2) * NUMBER_MESH_INTERVAL +
-            BATTLE_SIMULATOR_ICON_SIZE / 2 +
-            NUMBER_TO_ICON_MARGIN);
+        ? battleSimulatorIconOffsetX
+        : -battleSimulatorIconOffsetX;
 
     this.#battleSimulatorIcon.getObject3D().position.x = battleSimulatorIconX;
     this.#battleSimulatorIcon.getObject3D().position.y =

--- a/src/js/game-object/predicated-damage/view/predicated-damage-view.ts
+++ b/src/js/game-object/predicated-damage/view/predicated-damage-view.ts
@@ -161,9 +161,13 @@ export class PredicatedDamageView {
     }
 
     const battleSimulatorIconX =
-      (intervalCount / 2) * NUMBER_MESH_INTERVAL +
-      BATTLE_SIMULATOR_ICON_SIZE / 2 +
-      NUMBER_TO_ICON_MARGIN;
+      model.battleSimulatorIconPosition === "right"
+        ? (intervalCount / 2) * NUMBER_MESH_INTERVAL +
+            BATTLE_SIMULATOR_ICON_SIZE / 2 +
+            NUMBER_TO_ICON_MARGIN
+        : -((intervalCount / 2) * NUMBER_MESH_INTERVAL +
+            BATTLE_SIMULATOR_ICON_SIZE / 2 +
+            NUMBER_TO_ICON_MARGIN);
 
     this.#battleSimulatorIcon.getObject3D().position.x = battleSimulatorIconX;
     this.#battleSimulatorIcon.getObject3D().position.y =

--- a/src/js/game-object/predicated-damage/view/predicated-damage-view.ts
+++ b/src/js/game-object/predicated-damage/view/predicated-damage-view.ts
@@ -160,9 +160,10 @@ export class PredicatedDamageView {
       sign.animate(10 / MAX_ANIMATION);
     }
 
-    const battleSimulatorIconOffsetX = (intervalCount / 2) * NUMBER_MESH_INTERVAL +
-          BATTLE_SIMULATOR_ICON_SIZE / 2 +
-          NUMBER_TO_ICON_MARGIN;
+    const battleSimulatorIconOffsetX =
+      (intervalCount / 2) * NUMBER_MESH_INTERVAL +
+      BATTLE_SIMULATOR_ICON_SIZE / 2 +
+      NUMBER_TO_ICON_MARGIN;
     const battleSimulatorIconX =
       model.battleSimulatorIconPosition === "right"
         ? battleSimulatorIconOffsetX

--- a/src/js/td-scenes/battle/view/hud/player/procedure/create-enemy-props.ts
+++ b/src/js/td-scenes/battle/view/hud/player/procedure/create-enemy-props.ts
@@ -22,7 +22,10 @@ export function createEnemyProps(
     battery: enemy.armdozer.maxBattery,
   });
 
-  const predicatedDamage = new PredicatedDamage(params);
+  const predicatedDamage = new PredicatedDamage({
+    ...params,
+    battleSimulatorIconPosition: "left",
+  });
 
   const statusIcon = new StatusIcon(params);
 

--- a/src/js/td-scenes/battle/view/hud/player/procedure/create-player-props.ts
+++ b/src/js/td-scenes/battle/view/hud/player/procedure/create-player-props.ts
@@ -22,7 +22,10 @@ export function createPlayerProps(
     battery: player.armdozer.maxBattery,
   });
 
-  const predicatedDamage = new PredicatedDamage(params);
+  const predicatedDamage = new PredicatedDamage({
+    ...params,
+    battleSimulatorIconPosition: "right",
+  });
 
   const statusIcon = new StatusIcon(params);
 

--- a/src/js/td-scenes/battle/view/procedure/tracking/predicated-damage-tracking.ts
+++ b/src/js/td-scenes/battle/view/procedure/tracking/predicated-damage-tracking.ts
@@ -44,7 +44,7 @@ function playerPredicatedDamageTracking(
 function enemyPredicatedDamageTracking(params: PredicatedDamageTrackingParams) {
   const { predicatedDamage, tdCamera, rendererDOM } = params;
   const origin = {
-    x: -ARMDOZER_EFFECT_STANDARD_X + 60,
+    x: -ARMDOZER_EFFECT_STANDARD_X + 130,
     y: ARMDOZER_EFFECT_STANDARD_Y + 30,
     z: ARMDOZER_EFFECT_STANDARD_Z,
   };

--- a/src/js/td-scenes/battle/view/procedure/tracking/predicated-damage-tracking.ts
+++ b/src/js/td-scenes/battle/view/procedure/tracking/predicated-damage-tracking.ts
@@ -45,7 +45,7 @@ function enemyPredicatedDamageTracking(params: PredicatedDamageTrackingParams) {
   const { predicatedDamage, tdCamera, rendererDOM } = params;
   const origin = {
     x: -ARMDOZER_EFFECT_STANDARD_X + 130,
-    y: ARMDOZER_EFFECT_STANDARD_Y + 30,
+    y: ARMDOZER_EFFECT_STANDARD_Y,
     z: ARMDOZER_EFFECT_STANDARD_Z,
   };
   const hudCoordinate = toHUDCoordinate(origin, tdCamera, rendererDOM);

--- a/src/js/td-scenes/battle/view/procedure/tracking/predicated-damage-tracking.ts
+++ b/src/js/td-scenes/battle/view/procedure/tracking/predicated-damage-tracking.ts
@@ -44,7 +44,7 @@ function playerPredicatedDamageTracking(
 function enemyPredicatedDamageTracking(params: PredicatedDamageTrackingParams) {
   const { predicatedDamage, tdCamera, rendererDOM } = params;
   const origin = {
-    x: -ARMDOZER_EFFECT_STANDARD_X + 130,
+    x: -ARMDOZER_EFFECT_STANDARD_X + 150,
     y: ARMDOZER_EFFECT_STANDARD_Y,
     z: ARMDOZER_EFFECT_STANDARD_Z,
   };

--- a/stories/predicated-damage.stories.ts
+++ b/stories/predicated-damage.stories.ts
@@ -26,7 +26,9 @@ type CreatorParams = PredicatedDamageConstructParams & {
  */
 const createPredicatedDamage = (params: CreatorParams): THREE.Object3D => {
   const { damage } = params;
-  const predicatedDamage = new PredicatedDamage(params);
+  const predicatedDamage = new PredicatedDamage({
+    ...params,
+  });
   predicatedDamage.getObject3D().position.y = params.y ?? 0;
   predicatedDamage.show(damage).play();
   predicatedDamage.notifyPush().subscribe(() => {
@@ -43,28 +45,92 @@ const createPredicatedDamage = (params: CreatorParams): THREE.Object3D => {
 
 /** ダメージ予想の４桁単体表示 */
 export const fourDigitNumber = hudGameObjectStory((params) => [
-  createPredicatedDamage({ ...params, damage: 2000 }),
+  createPredicatedDamage({
+    ...params,
+    damage: 2000,
+    battleSimulatorIconPosition: "right",
+  }),
 ]);
 
 /** ダメージ予想の3桁単体表示 */
 export const threeDigitNumber = hudGameObjectStory((params) => [
-  createPredicatedDamage({ ...params, damage: 650 }),
+  createPredicatedDamage({
+    ...params,
+    damage: 650,
+    battleSimulatorIconPosition: "right",
+  }),
 ]);
 
 /** ダメージ予想の2桁単体表示 */
 export const twoDigitNumber = hudGameObjectStory((params) => [
-  createPredicatedDamage({ ...params, damage: 10 }),
+  createPredicatedDamage({
+    ...params,
+    damage: 10,
+    battleSimulatorIconPosition: "right",
+  }),
 ]);
 
 /** ダメージ予想の1桁単体表示 */
 export const oneDigitNumber = hudGameObjectStory((params) => [
-  createPredicatedDamage({ ...params, damage: 1 }),
+  createPredicatedDamage({
+    ...params,
+    damage: 1,
+    battleSimulatorIconPosition: "right",
+  }),
 ]);
 
 /** ダメージ予想の複数表示 */
 export const multi = hudGameObjectStory((params) => [
-  createPredicatedDamage({ ...params, damage: 2000, y: 0 }),
-  createPredicatedDamage({ ...params, damage: 200, y: 50 }),
-  createPredicatedDamage({ ...params, damage: 20, y: 100 }),
-  createPredicatedDamage({ ...params, damage: 2, y: 150 }),
+  createPredicatedDamage({
+    ...params,
+    damage: 2000,
+    y: 0,
+    battleSimulatorIconPosition: "right",
+  }),
+  createPredicatedDamage({
+    ...params,
+    damage: 200,
+    y: 50,
+    battleSimulatorIconPosition: "right",
+  }),
+  createPredicatedDamage({
+    ...params,
+    damage: 20,
+    y: 100,
+    battleSimulatorIconPosition: "right",
+  }),
+  createPredicatedDamage({
+    ...params,
+    damage: 2,
+    y: 150,
+    battleSimulatorIconPosition: "right",
+  }),
+]);
+
+/** ダメージ予想の複数表示(left) */
+export const multiLeft = hudGameObjectStory((params) => [
+  createPredicatedDamage({
+    ...params,
+    damage: 2000,
+    y: 0,
+    battleSimulatorIconPosition: "left",
+  }),
+  createPredicatedDamage({
+    ...params,
+    damage: 200,
+    y: 50,
+    battleSimulatorIconPosition: "left",
+  }),
+  createPredicatedDamage({
+    ...params,
+    damage: 20,
+    y: 100,
+    battleSimulatorIconPosition: "left",
+  }),
+  createPredicatedDamage({
+    ...params,
+    damage: 2,
+    y: 150,
+    battleSimulatorIconPosition: "left",
+  }),
 ]);


### PR DESCRIPTION
This pull request adds support for specifying the position ("left" or "right") of the battle simulator icon in the predicted damage UI. The changes introduce a new property to control the icon's alignment, update constructors and initializers to accept this property, and adjust the rendering logic to position the icon accordingly. The updates are reflected throughout the model, props, view logic, and storybook examples.

**Support for battle simulator icon position:**

* Added a new type `BattleSimulatorIconPosition` ("right" | "left") and included it as a property in the `PredicatedDamageModel`. The model's initializer and related props were updated to require this property. [[1]](diffhunk://#diff-a71a70657887ea055bde37b45b7b2718b7875d16c7c170840e6182af2d9d3721R1-R3) [[2]](diffhunk://#diff-a71a70657887ea055bde37b45b7b2718b7875d16c7c170840e6182af2d9d3721R16-R17) [[3]](diffhunk://#diff-c791fcb283148d428f64b0107082a6381da32ee073302a728b873b9fe26445eeL1-R18) [[4]](diffhunk://#diff-7d2774dd70eb18f291990a406b9b3f6c433ec9ace9d08a4aa336f96181a06749R3) [[5]](diffhunk://#diff-7d2774dd70eb18f291990a406b9b3f6c433ec9ace9d08a4aa336f96181a06749L12-R17) [[6]](diffhunk://#diff-7d2774dd70eb18f291990a406b9b3f6c433ec9ace9d08a4aa336f96181a06749R27-R30)
* Modified the `PredicatedDamageView` rendering logic to position the battle simulator icon based on the new `battleSimulatorIconPosition` property.

**Integration with player/enemy HUD and storybook:**

* Updated the player and enemy HUD creation functions to pass the appropriate icon position ("right" for player, "left" for enemy) when constructing predicted damage objects. [[1]](diffhunk://#diff-5ae0408f04651d3432cce403a498548ad16bd77c9d34e59eade862ff3521fda0L25-R28) [[2]](diffhunk://#diff-da7253fca305b153341691e59e1bf830079733d822f67de90b6a050354ba2305L25-R28)
* Enhanced storybook stories to support and demonstrate both "left" and "right" icon positions, including new multi-icon display variants. [[1]](diffhunk://#diff-0d29183d100ae3bf630b9d160138b9f575655643f5abd1a5983132b3bc8a2840L29-R31) [[2]](diffhunk://#diff-0d29183d100ae3bf630b9d160138b9f575655643f5abd1a5983132b3bc8a2840L46-R135)

**Minor UI adjustment:**

* Adjusted the enemy predicted damage tracking origin for improved HUD alignment.