### PR TITLE
リリースブランチのdevelopへのマージ

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -211,7 +211,6 @@ shfmt -l -w *.bash
 | /GbraverBurst/prod/privacyPolicyUrl        | String | プライバシーポリシーページのURL           |
 | /GbraverBurst/prod/contactURL              | String | 問い合わせページのURL                     |
 | /GbraverBurst/prod/cognitoHostedUIDomain   | String | cognito Hosted UI のドメイン              |
-| /GbraverBurst/prod/coturnDomainName        | String | coturnサーバーのドメイン名                |
 
 ### IAMポリシー
 

--- a/buildspec.prod.yml
+++ b/buildspec.prod.yml
@@ -4,17 +4,17 @@ env:
     IS_SEARCH_ENGINE_NO_INDEX: false
     IS_SERVICE_WORKER_USED: true
     APP_ICON_TYPE: "PROD"
-    CAN_ONLINE_BETA: false
     CAN_PLAY_DEVELOPING_ARMDOZER: false
     CAN_PLAY_DEVELOPING_PILOT: false
     CAN_PLAY_EPISODE_IN_DEVELOPMENT: false
     IS_TITLE_HELP_ICON_ENABLE: true
     NETWORK_MODE: "ONLINE"
+    CAN_ONLINE_BETA: false
   parameter-store:
     SERVICE: /GbraverBurst/prod/service
     STAGE: /GbraverBurst/prod/stage
     WS_API_DOMAIN_NAME: /GbraverBurst/prod/wsApiDomainName
-    WS_SIGNAL_DOMAIN_NAME: /GbraverBurst/prod/wsSignalDomainName
+    # WS_SIGNAL_DOMAIN_NAME: /GbraverBurst/prod/wsSignalDomainName #あいことば対戦正式リリースまでコメントアウトする
     ASSETLINKS_JSON_URI: /GbraverBurst/prod/assetlinksJsonURI
     S3_BUCKET: /GbraverBurst/prod/s3Bucket
     DISTRIBUTION_ID: /GbraverBurst/prod/distributionId
@@ -28,8 +28,8 @@ env:
     COGNITO_USER_POOL_ID: /GbraverBurst/prod/cognitoUserPoolId
     COGNITO_CLIENT_ID: /GbraverBurst/prod/cognitoClientId
     COGNITO_HOSTED_UI_DOMAIN: /GbraverBurst/prod/cognitoHostedUIDomain
-    WEBRTC_HELPER_DOMAIN_NAME: /GbraverBurst/prod/webrtcHelperDomainName
-    COTURN_DOMAIN_NAME: /GbraverBurst/prod/coturnDomainName
+    # WEBRTC_HELPER_DOMAIN_NAME: /GbraverBurst/prod/webrtcHelperDomainName #あいことば対戦正式リリースまでコメントアウトする
+    # COTURN_DOMAIN_NAME: /GbraverBurst/prod/coturnDomainName #あいことば対戦正式リリースまでコメントアウトする
 phases:
   install:
     runtime-versions:
@@ -40,7 +40,7 @@ phases:
   build:
     commands:
       - export WEBSOCKET_API_URL="wss://${STAGE}.${WS_API_DOMAIN_NAME}"
-      - export SIGNAL_SERVER_URL="wss://${STAGE}.${WS_SIGNAL_DOMAIN_NAME}"
-      - export WEBRTC_HELPER_API_URL="https://${STAGE}.${WEBRTC_HELPER_DOMAIN_NAME}"
+      # - export SIGNAL_SERVER_URL="wss://${STAGE}.${WS_SIGNAL_DOMAIN_NAME}" #あいことば対戦正式リリースまでコメントアウトする
+      # - export WEBRTC_HELPER_API_URL="https://${STAGE}.${WEBRTC_HELPER_DOMAIN_NAME}" #あいことば対戦正式リリースまでコメントアウトする
       - ./deploy.bash "${S3_BUCKET}" "${STAGE}" "${ASSETLINKS_JSON_URI}"
       - ./clear-cdn.bash "${DISTRIBUTION_ID}"

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -4,12 +4,12 @@ env:
     IS_SEARCH_ENGINE_NO_INDEX: true
     IS_SERVICE_WORKER_USED: true
     APP_ICON_TYPE: "DEV"
-    CAN_ONLINE_BETA: true
     CAN_PLAY_DEVELOPING_ARMDOZER: true
     CAN_PLAY_DEVELOPING_PILOT: true
     CAN_PLAY_EPISODE_IN_DEVELOPMENT: true
     IS_TITLE_HELP_ICON_ENABLE: true
     NETWORK_MODE: "ONLINE"
+    CAN_ONLINE_BETA: true
   parameter-store:
     SERVICE: /GbraverBurst/dev/service
     STAGE: /GbraverBurst/dev/stage


### PR DESCRIPTION
This pull request primarily comments out configuration and environment variables related to the "あいことば対戦" (keyword match) feature in both production and development build specifications, in preparation for its formal release. No logic or functional code is changed; only configuration references are affected.

Configuration and environment variable adjustments:

* In `buildspec.prod.yml` and `buildspec.yml`, variables and exports related to the signal server, WebRTC helper, and coturn server are now commented out with notes indicating they will remain disabled until the official release of the keyword match feature. [[1]](diffhunk://#diff-95a4779a60c8981757068733208a2aeb744c9097412aa27da62fbd0b6442e8caL7-R17) [[2]](diffhunk://#diff-95a4779a60c8981757068733208a2aeb744c9097412aa27da62fbd0b6442e8caL31-R32) [[3]](diffhunk://#diff-95a4779a60c8981757068733208a2aeb744c9097412aa27da62fbd0b6442e8caL43-R44)
* The `coturnDomainName` entry is removed from the documentation table in `Readme.md` to reflect its temporary deactivation.

No functional or behavioral changes are introduced by this pull request; it is limited to configuration management in anticipation of a future feature release.