### PR TITLE
プレイヤー選択にバトルモードを出すようにした

### DIFF
--- a/src/js/dom-dialogs/net-battle-selector/dom/root-inner-html.hbs
+++ b/src/js/dom-dialogs/net-battle-selector/dom/root-inner-html.hbs
@@ -11,7 +11,7 @@
     alt="カジュアルマッチをする"
     data-id="{{ids.casualMatchButton}}"
   >
-    <div class="{{ROOT_CLASS}}__casual-match-title">カジュアルマッチ</div>
+    <div class="{{ROOT_CLASS}}__casual-match-title">🎮カジュアルマッチ</div>
     <div
       class="{{ROOT_CLASS}}__casual-match-description"
     >{{casualMatchDescription}}</div>
@@ -22,7 +22,7 @@
     data-id="{{ids.privateMatchHostButton}}"
   >
     <div class="{{ROOT_CLASS}}__private-match-host-title">
-      プライベートマッチ<wbr />（ホスト）
+      👑プライベートマッチ<wbr />（ホスト）
     </div>
     <div
       class="{{ROOT_CLASS}}__private-match-host-description"
@@ -34,7 +34,7 @@
     data-id="{{ids.privateMatchGuestButton}}"
   >
     <div class="{{ROOT_CLASS}}__private-match-guest-title">
-      プライベートマッチ<wbr />（ゲスト）
+      🙋プライベートマッチ<wbr />（ゲスト）
     </div>
     <div
       class="{{ROOT_CLASS}}__private-match-guest-description"

--- a/src/js/game/game-procedure/on-game-action/on-arcade-start.ts
+++ b/src/js/game/game-procedure/on-game-action/on-arcade-start.ts
@@ -32,7 +32,11 @@ export async function onArcadeStart(options: Options): Promise<void> {
   await props.fader.fadeOut();
   const config = await props.config.load();
   await Promise.race([
-    bindPlayerSelectAccordingToConfig(props, config.playerSelectorType),
+    bindPlayerSelectAccordingToConfig(
+      props,
+      config.playerSelectorType,
+      "🕹️アーケード",
+    ),
     waitTime(MAX_LOADING_TIME),
   ]);
   await props.fader.fadeIn();

--- a/src/js/game/game-procedure/on-game-action/on-casual-match-start.ts
+++ b/src/js/game/game-procedure/on-game-action/on-casual-match-start.ts
@@ -34,7 +34,7 @@ export async function onCasualMatchStart(options: Options): Promise<void> {
     bindPlayerSelectAccordingToConfig(
       props,
       config.playerSelectorType,
-      "カジュアルマッチ",
+      "🎮カジュアルマッチ",
     ),
     waitTime(MAX_LOADING_TIME),
   ]);

--- a/src/js/game/game-procedure/on-game-action/on-casual-match-start.ts
+++ b/src/js/game/game-procedure/on-game-action/on-casual-match-start.ts
@@ -31,7 +31,11 @@ export async function onCasualMatchStart(options: Options): Promise<void> {
   await props.fader.fadeOut();
   const config = await props.config.load();
   await Promise.race([
-    bindPlayerSelectAccordingToConfig(props, config.playerSelectorType),
+    bindPlayerSelectAccordingToConfig(
+      props,
+      config.playerSelectorType,
+      "カジュアルマッチ",
+    ),
     waitTime(MAX_LOADING_TIME),
   ]);
   await props.fader.fadeIn();

--- a/src/js/game/game-procedure/on-game-action/on-net-battle-start/start-offline-lan-net-battle.ts
+++ b/src/js/game/game-procedure/on-game-action/on-net-battle-start/start-offline-lan-net-battle.ts
@@ -21,7 +21,11 @@ export async function startOfflineLANNetBattle(
   await props.fader.fadeOut();
   const config = await props.config.load();
   await Promise.race([
-    bindPlayerSelectAccordingToConfig(props, config.playerSelectorType),
+    bindPlayerSelectAccordingToConfig(
+      props,
+      config.playerSelectorType,
+      "ネット対戦",
+    ),
     waitTime(MAX_LOADING_TIME),
   ]);
   await props.fader.fadeIn();

--- a/src/js/game/game-procedure/on-game-action/on-private-match-guest-start.ts
+++ b/src/js/game/game-procedure/on-game-action/on-private-match-guest-start.ts
@@ -35,7 +35,11 @@ export async function onPrivateMatchGuestStart(
   await props.fader.fadeOut();
   const config = await props.config.load();
   await Promise.race([
-    bindPlayerSelectAccordingToConfig(props, config.playerSelectorType),
+    bindPlayerSelectAccordingToConfig(
+      props,
+      config.playerSelectorType,
+      "プライベートマッチ（ゲスト）",
+    ),
     waitTime(MAX_LOADING_TIME),
   ]);
   await props.fader.fadeIn();

--- a/src/js/game/game-procedure/on-game-action/on-private-match-guest-start.ts
+++ b/src/js/game/game-procedure/on-game-action/on-private-match-guest-start.ts
@@ -38,7 +38,7 @@ export async function onPrivateMatchGuestStart(
     bindPlayerSelectAccordingToConfig(
       props,
       config.playerSelectorType,
-      "プライベートマッチ（ゲスト）",
+      "🙋ゲスト",
     ),
     waitTime(MAX_LOADING_TIME),
   ]);

--- a/src/js/game/game-procedure/on-game-action/on-private-match-host-start.ts
+++ b/src/js/game/game-procedure/on-game-action/on-private-match-host-start.ts
@@ -34,7 +34,7 @@ export async function onPrivateMatchHostStart(options: Options): Promise<void> {
     bindPlayerSelectAccordingToConfig(
       props,
       config.playerSelectorType,
-      "プライベートマッチ（ホスト）",
+      "👑ホスト",
     ),
     waitTime(MAX_LOADING_TIME),
   ]);

--- a/src/js/game/game-procedure/on-game-action/on-private-match-host-start.ts
+++ b/src/js/game/game-procedure/on-game-action/on-private-match-host-start.ts
@@ -31,7 +31,11 @@ export async function onPrivateMatchHostStart(options: Options): Promise<void> {
   await props.fader.fadeOut();
   const config = await props.config.load();
   await Promise.race([
-    bindPlayerSelectAccordingToConfig(props, config.playerSelectorType),
+    bindPlayerSelectAccordingToConfig(
+      props,
+      config.playerSelectorType,
+      "プライベートマッチ（ホスト）",
+    ),
     waitTime(MAX_LOADING_TIME),
   ]);
   await props.fader.fadeIn();


### PR DESCRIPTION
This pull request updates the UI and related logic for the net battle selector and match start procedures by introducing emoji icons to visually distinguish different match types. These changes affect both the displayed labels in the UI and the parameters passed to the player selection logic.

UI improvements (visual distinction of match types):

* Added emojis to the match type titles in `root-inner-html.hbs` to help users quickly identify each match type:
  - 🎮 for "カジュアルマッチ" (Casual Match)
  - 👑 for "プライベートマッチ（ホスト）" (Private Match Host)
  - 🙋 for "プライベートマッチ（ゲスト）" (Private Match Guest)

Logic updates (player selection procedure):

* Updated calls to `bindPlayerSelectAccordingToConfig` in the match start procedures to include the new emoji-labeled match type names as parameters:
  - "🎮カジュアルマッチ" for casual matches (`on-casual-match-start.ts`)
  - "ネット対戦" for offline LAN net battles (`start-offline-lan-net-battle.ts`)
  - "👑ホスト" for private match hosts (`on-private-match-host-start.ts`)
  - "🙋ゲスト" for private match guests (`on-private-match-guest-start.ts`)