### PR TITLE
プライベートマッチの文言を短くした

### DIFF
--- a/src/js/dom-dialogs/net-battle-selector/dom/root-inner-html.hbs
+++ b/src/js/dom-dialogs/net-battle-selector/dom/root-inner-html.hbs
@@ -18,11 +18,11 @@
   </button>
   <button
     class="{{ROOT_CLASS}}__private-match-host"
-    alt="プライベートマッチ（ホスト）をする"
+    alt="ルーム作成をする"
     data-id="{{ids.privateMatchHostButton}}"
   >
     <div class="{{ROOT_CLASS}}__private-match-host-title">
-      👑プライベートマッチ<wbr />（ホスト）
+      👑ルーム作成
     </div>
     <div
       class="{{ROOT_CLASS}}__private-match-host-description"
@@ -30,11 +30,11 @@
   </button>
   <button
     class="{{ROOT_CLASS}}__private-match-guest"
-    alt="プライベートマッチ（ゲスト）をする"
+    alt="ルーム参加をする"
     data-id="{{ids.privateMatchGuestButton}}"
   >
     <div class="{{ROOT_CLASS}}__private-match-guest-title">
-      🙋プライベートマッチ<wbr />（ゲスト）
+      🙋ルーム参加
     </div>
     <div
       class="{{ROOT_CLASS}}__private-match-guest-description"

--- a/src/js/dom-dialogs/net-battle-selector/dom/root-inner-html.hbs
+++ b/src/js/dom-dialogs/net-battle-selector/dom/root-inner-html.hbs
@@ -8,7 +8,6 @@
   />
   <button
     class="{{ROOT_CLASS}}__casual-match"
-    alt="カジュアルマッチをする"
     data-id="{{ids.casualMatchButton}}"
   >
     <div class="{{ROOT_CLASS}}__casual-match-title">🎮カジュアルマッチ</div>
@@ -18,7 +17,6 @@
   </button>
   <button
     class="{{ROOT_CLASS}}__private-match-host"
-    alt="ルーム作成をする"
     data-id="{{ids.privateMatchHostButton}}"
   >
     <div class="{{ROOT_CLASS}}__private-match-host-title">
@@ -30,7 +28,6 @@
   </button>
   <button
     class="{{ROOT_CLASS}}__private-match-guest"
-    alt="ルーム参加をする"
     data-id="{{ids.privateMatchGuestButton}}"
   >
     <div class="{{ROOT_CLASS}}__private-match-guest-title">

--- a/src/js/game/game-procedure/on-game-action/on-private-match-guest-start.ts
+++ b/src/js/game/game-procedure/on-game-action/on-private-match-guest-start.ts
@@ -38,7 +38,7 @@ export async function onPrivateMatchGuestStart(
     bindPlayerSelectAccordingToConfig(
       props,
       config.playerSelectorType,
-      "🙋ゲスト",
+      "🙋ルーム参加",
     ),
     waitTime(MAX_LOADING_TIME),
   ]);

--- a/src/js/game/game-procedure/on-game-action/on-private-match-host-start.ts
+++ b/src/js/game/game-procedure/on-game-action/on-private-match-host-start.ts
@@ -34,7 +34,7 @@ export async function onPrivateMatchHostStart(options: Options): Promise<void> {
     bindPlayerSelectAccordingToConfig(
       props,
       config.playerSelectorType,
-      "👑ホスト",
+      "👑ルーム作成",
     ),
     waitTime(MAX_LOADING_TIME),
   ]);


### PR DESCRIPTION
This pull request updates the terminology used for private matches in both the UI and game logic to use more user-friendly language. The main change is replacing "host" and "guest" with "ルーム作成" (room creation) and "ルーム参加" (room join/participation), respectively, for a clearer and more intuitive user experience.

**UI text and label updates:**

* Changed button labels, alt text, and titles in `root-inner-html.hbs` from "プライベートマッチ（ホスト）" and "プライベートマッチ（ゲスト）" to "ルーム作成" and "ルーム参加" for both host and guest options.

**Game logic and prompts:**

* Updated the label passed to `bindPlayerSelectAccordingToConfig` in `on-private-match-host-start.ts` from "👑ホスト" to "👑ルーム作成".
* Updated the label passed to `bindPlayerSelectAccordingToConfig` in `on-private-match-guest-start.ts` from "🙋ゲスト" to "🙋ルーム参加".