### PR TITLE
ステータスダイアログの幅を調整

### DIFF
--- a/src/css/net-battle-selector.css
+++ b/src/css/net-battle-selector.css
@@ -40,7 +40,7 @@
   width: min(
     calc(
       100vw - var(--safe-area-right) - var(--safe-area-left) -
-        var(--closer-width) * 0.5
+        var(--closer-width)
     ),
     90vw
   );

--- a/src/css/status.css
+++ b/src/css/status.css
@@ -57,12 +57,12 @@
   box-sizing: border-box;
   padding: max(var(--closer-height) / 2, var(--dialog-padding))
     var(--dialog-padding) var(--dialog-padding) var(--dialog-padding);
-  width: calc(
-    100dvw -
-      max(
-        var(--safe-area-right) + var(--safe-area-left),
-        var(--closer-width) + var(--responsive-font-size) * 2
-      )
+  width: min(
+    calc(
+      100vw - var(--safe-area-right) - var(--safe-area-left) -
+        var(--closer-width)
+    ),
+    90vw
   );
   height: calc(
     100dvh -

--- a/src/css/status.css
+++ b/src/css/status.css
@@ -62,7 +62,7 @@
       100vw - var(--safe-area-right) - var(--safe-area-left) -
         var(--closer-width)
     ),
-    90vw
+    80vw
   );
   height: calc(
     100dvh -


### PR DESCRIPTION
This pull request updates the layout calculations in the CSS files to improve how dialog and selector components size themselves, particularly regarding viewport width and safe area insets. The changes simplify and unify the width calculations for better consistency and responsiveness.

**Layout and Responsiveness Improvements:**

* Updated the width calculation in `src/css/net-battle-selector.css` to subtract the full value of `--closer-width` instead of half, ensuring consistent spacing and alignment.
* Refactored the width calculation in `src/css/status.css` to use a simpler and more consistent formula, aligning it with the approach used in the selector and capping the width at 80vw for improved responsiveness.