### PR TITLE
fix: QRコード表示をキャンバスから画像に変更し、スタイルを追加

### DIFF
--- a/src/css/private-match-host.css
+++ b/src/css/private-match-host.css
@@ -41,6 +41,12 @@
   left: max(var(--safe-area-left), calc(var(--closer-height) * 0.3));
 }
 
+.private-match-host__qr-code {
+  aspect-ratio: 1 / 1;
+  min-height: 164px;
+  flex: 1;
+}
+
 .private-match-host__qr-code-description {
   margin-bottom: calc(var(--responsive-font-size) * 0.5);
 }

--- a/src/js/dom-dialogs/private-match-host/dom/elements.ts
+++ b/src/js/dom-dialogs/private-match-host/dom/elements.ts
@@ -7,17 +7,17 @@ export const extractCloser = (root: HTMLElement): HTMLElement =>
   root.querySelector(`[data-id="closer"]`) ?? document.createElement("div");
 
 /**
- * QRコード表示キャンバスを抽出する
+ * QRコード表示領域を抽出する
  * @param root ルート要素
  * @returns 抽出結果
  */
-export const extractQRCode = (root: HTMLElement): HTMLCanvasElement => {
+export const extractQRCode = (root: HTMLElement): HTMLImageElement => {
   const extractedQRCode = root.querySelector(
     `[data-id="qr-code"]`,
   ) as HTMLCanvasElement;
-  return extractedQRCode instanceof HTMLCanvasElement
+  return extractedQRCode instanceof HTMLImageElement
     ? extractedQRCode
-    : document.createElement("canvas");
+    : document.createElement("img");
 };
 
 /**

--- a/src/js/dom-dialogs/private-match-host/dom/elements.ts
+++ b/src/js/dom-dialogs/private-match-host/dom/elements.ts
@@ -12,9 +12,7 @@ export const extractCloser = (root: HTMLElement): HTMLElement =>
  * @returns 抽出結果
  */
 export const extractQRCode = (root: HTMLElement): HTMLImageElement => {
-  const extractedQRCode = root.querySelector(
-    `[data-id="qr-code"]`,
-  ) as HTMLCanvasElement;
+  const extractedQRCode = root.querySelector(`[data-id="qr-code"]`);
   return extractedQRCode instanceof HTMLImageElement
     ? extractedQRCode
     : document.createElement("img");

--- a/src/js/dom-dialogs/private-match-host/dom/root-inner-html.hbs
+++ b/src/js/dom-dialogs/private-match-host/dom/root-inner-html.hbs
@@ -8,7 +8,7 @@
   <div
     class="{{ROOT_CLASS}}__qr-code-description"
   >QRコードを共有してプライベートマッチ開始</div>
-  <img class="{{ROOT_CLASS}}__qr-code" data-id="qr-code" />
+  <img alt="QRコード" class="{{ROOT_CLASS}}__qr-code" data-id="qr-code" />
   <div class="{{ROOT_CLASS}}__separator">or</div>
   <div class="{{ROOT_CLASS}}__room-id">
     <div

--- a/src/js/dom-dialogs/private-match-host/dom/root-inner-html.hbs
+++ b/src/js/dom-dialogs/private-match-host/dom/root-inner-html.hbs
@@ -8,7 +8,7 @@
   <div
     class="{{ROOT_CLASS}}__qr-code-description"
   >QRコードを共有してプライベートマッチ開始</div>
-  <canvas class="{{ROOT_CLASS}}__qr-code" data-id="qr-code"></canvas>
+  <img class="{{ROOT_CLASS}}__qr-code" data-id="qr-code" />
   <div class="{{ROOT_CLASS}}__separator">or</div>
   <div class="{{ROOT_CLASS}}__room-id">
     <div

--- a/src/js/qr-code/private-match-qr-code.ts
+++ b/src/js/qr-code/private-match-qr-code.ts
@@ -22,8 +22,6 @@ export const drawPrivateMatchQRCode = async (
     type: "svg",
   });
   img.src = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`;
-  //img.style.minWidth = "164px";
-  //img.style.minHeight = "164px";
 };
 
 /**

--- a/src/js/qr-code/private-match-qr-code.ts
+++ b/src/js/qr-code/private-match-qr-code.ts
@@ -9,16 +9,21 @@ export const createPrivateMatchQRCodeText = (roomID: string): string =>
   `gbraver-burst-private-match:${roomID}`;
 
 /**
- * プライベートマッチQRコードをキャンバスに描画する
- * @param canvas 描画対象のキャンバス
+ * プライベートマッチQRコードを描画する
+ * @param img 描画対象
  * @param roomID ルームID
  * @returns 処理結果
  */
 export const drawPrivateMatchQRCode = async (
-  canvas: HTMLCanvasElement,
+  img: HTMLImageElement,
   roomID: string,
 ) => {
-  await QRCode.toCanvas(canvas, createPrivateMatchQRCodeText(roomID));
+  const svg = await QRCode.toString(createPrivateMatchQRCodeText(roomID), {
+    type: "svg",
+  });
+  img.src = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`;
+  //img.style.minWidth = "164px";
+  //img.style.minHeight = "164px";
 };
 
 /**


### PR DESCRIPTION
This pull request updates the way QR codes are rendered and handled in the private match host dialog, switching from using a `<canvas>` element to an `<img>` element that displays an SVG. This change improves QR code rendering quality and flexibility. The main changes are grouped below:

**QR Code Rendering Refactor:**

* The QR code display element in the dialog has been changed from a `<canvas>` to an `<img>`, and the QR code is now rendered as an SVG and set as the `src` of the image. This improves rendering quality and makes the QR code more easily scalable. [[1]](diffhunk://#diff-7871fbdeed6a787a3dc0485b2fc618d1946c97c2e0df409d4c4b37c29e354db7L11-R11) [[2]](diffhunk://#diff-eb3d2d7d30a29abce4d82d23a071366d65947c17e40dfc5b138c4d4660228d96L12-R26)
* The function `drawPrivateMatchQRCode` was updated to generate an SVG QR code and assign it to the `img.src` property, instead of drawing directly to a canvas.
* The DOM extraction utility `extractQRCode` was updated to work with `HTMLImageElement` instead of `HTMLCanvasElement`, ensuring correct element handling throughout the codebase.

**Styling Updates:**

* Added new CSS rules for `.private-match-host__qr-code` to ensure the image maintains a square aspect ratio and a minimum height, improving layout consistency.