### PR TITLE
ダメージ予想の位置を変更

### DIFF
--- a/src/js/game-object/armdozer/armdozer-sprite.ts
+++ b/src/js/game-object/armdozer/armdozer-sprite.ts
@@ -2,8 +2,8 @@ import * as THREE from "three";
 
 import { Animate } from "../../animation/animate";
 
-/** ステータスアイコンの位置（ワールド座標） */
-export type StatusIconPosition = {
+/** アームドーザ用ワールド座標 */
+export type ArmdozerWorldCoordinate = {
   /** x軸 */
   x: number;
   /** y軸 */
@@ -15,7 +15,9 @@ export type StatusIconPosition = {
 /** アームドーザスプライト */
 export interface ArmdozerSprite {
   /** ステータスアイコンの位置（ワールド座標） */
-  readonly statusIconPosition: StatusIconPosition;
+  readonly statusIconPosition: ArmdozerWorldCoordinate;
+  /** ダメージ予想の位置（ワールド座標） */
+  readonly predicatedDamagePosition: ArmdozerWorldCoordinate;
   /** ダウンアニメーション開始から衝撃演出までの遅延時間(ミリ秒) */
   readonly downImpactDelay: number;
   /**

--- a/src/js/game-object/armdozer/empty-armdozer-sprite.ts
+++ b/src/js/game-object/armdozer/empty-armdozer-sprite.ts
@@ -20,6 +20,12 @@ export class EmptyArmdozerSprite implements ArmdozerSprite {
     y: ARMDOZER_EFFECT_STANDARD_Y + 80,
     z: ARMDOZER_EFFECT_STANDARD_Z,
   };
+  /** @override */
+  predicatedDamagePosition = {
+    x: ARMDOZER_EFFECT_STANDARD_X - 30,
+    y: ARMDOZER_EFFECT_STANDARD_Y + 30,
+    z: ARMDOZER_EFFECT_STANDARD_Z,
+  };
 
   /** @override */
   downImpactDelay = 800;

--- a/src/js/game-object/armdozer/genesis-braver/genesis-braver.ts
+++ b/src/js/game-object/armdozer/genesis-braver/genesis-braver.ts
@@ -58,6 +58,7 @@ export class GenesisBraver
     const { gameObjectAction } = params;
     this.#props = createGenesisBraverProps(params);
     this.statusIconPosition = this.#props.view.statusIconPosition;
+    this.predicatedDamagePosition = this.#props.view.predicatedDamagePosition;
     this.#unsubscribers = bindEventListeners({
       gameObjectAction,
       props: this.#props,

--- a/src/js/game-object/armdozer/genesis-braver/view/enemy-genesis-braver-view.ts
+++ b/src/js/game-object/armdozer/genesis-braver/view/enemy-genesis-braver-view.ts
@@ -11,6 +11,7 @@ export class EnemyGenesisBraverView extends PlayerGenesisBraverView {
   constructor(resources: Resources) {
     super(resources);
     this.statusIconPosition.x *= -1;
+    this.predicatedDamagePosition.x *= -1;
   }
 
   /** @override */

--- a/src/js/game-object/armdozer/genesis-braver/view/genesis-braver-view.ts
+++ b/src/js/game-object/armdozer/genesis-braver/view/genesis-braver-view.ts
@@ -7,6 +7,8 @@ import { GenesisBraverModel } from "../model/genesis-braver-model";
 export interface GenesisBraverView {
   /** ステータスアイコンの位置情報（ワールド座標） */
   statusIconPosition: ArmdozerWorldCoordinate;
+  /** 予測ダメージの位置情報（ワールド座標） */
+  predicatedDamagePosition: ArmdozerWorldCoordinate;
 
   /**
    * デストラクタ相当の処理

--- a/src/js/game-object/armdozer/genesis-braver/view/genesis-braver-view.ts
+++ b/src/js/game-object/armdozer/genesis-braver/view/genesis-braver-view.ts
@@ -1,12 +1,12 @@
 import * as THREE from "three";
 
-import { StatusIconPosition } from "../../armdozer-sprite";
+import { ArmdozerWorldCoordinate } from "../../armdozer-sprite";
 import { GenesisBraverModel } from "../model/genesis-braver-model";
 
 /** ジェネシスブレイバービュー */
 export interface GenesisBraverView {
   /** ステータスアイコンの位置情報（ワールド座標） */
-  statusIconPosition: StatusIconPosition;
+  statusIconPosition: ArmdozerWorldCoordinate;
 
   /**
    * デストラクタ相当の処理

--- a/src/js/game-object/armdozer/genesis-braver/view/player-genesis-braver-view.ts
+++ b/src/js/game-object/armdozer/genesis-braver/view/player-genesis-braver-view.ts
@@ -6,7 +6,7 @@ import {
   ARMDOZER_EFFECT_STANDARD_Y,
   ARMDOZER_EFFECT_STANDARD_Z,
 } from "../../../td-position";
-import { StatusIconPosition } from "../../armdozer-sprite";
+import { ArmdozerWorldCoordinate } from "../../armdozer-sprite";
 import { createAllMeshes } from "../mesh";
 import { AnimationMesh } from "../mesh/animation-mesh";
 import { GenesisBraverModel } from "../model/genesis-braver-model";
@@ -15,7 +15,7 @@ import { GenesisBraverView } from "./genesis-braver-view";
 /** プレイヤー ジェネシスブレイバービュー */
 export class PlayerGenesisBraverView implements GenesisBraverView {
   /** @override */
-  statusIconPosition: StatusIconPosition;
+  statusIconPosition: ArmdozerWorldCoordinate;
   /** グループ */
   #group: THREE.Group;
   /** メッシュ */

--- a/src/js/game-object/armdozer/genesis-braver/view/player-genesis-braver-view.ts
+++ b/src/js/game-object/armdozer/genesis-braver/view/player-genesis-braver-view.ts
@@ -18,7 +18,6 @@ export class PlayerGenesisBraverView implements GenesisBraverView {
   statusIconPosition: ArmdozerWorldCoordinate;
   /** @override */
   predicatedDamagePosition: ArmdozerWorldCoordinate;
-
   /** グループ */
   #group: THREE.Group;
   /** メッシュ */

--- a/src/js/game-object/armdozer/genesis-braver/view/player-genesis-braver-view.ts
+++ b/src/js/game-object/armdozer/genesis-braver/view/player-genesis-braver-view.ts
@@ -16,6 +16,9 @@ import { GenesisBraverView } from "./genesis-braver-view";
 export class PlayerGenesisBraverView implements GenesisBraverView {
   /** @override */
   statusIconPosition: ArmdozerWorldCoordinate;
+  /** @override */
+  predicatedDamagePosition: ArmdozerWorldCoordinate;
+
   /** グループ */
   #group: THREE.Group;
   /** メッシュ */
@@ -29,6 +32,11 @@ export class PlayerGenesisBraverView implements GenesisBraverView {
     this.statusIconPosition = {
       x: ARMDOZER_EFFECT_STANDARD_X - 90,
       y: ARMDOZER_EFFECT_STANDARD_Y + 80,
+      z: ARMDOZER_EFFECT_STANDARD_Z,
+    };
+    this.predicatedDamagePosition = {
+      x: ARMDOZER_EFFECT_STANDARD_X - 50,
+      y: ARMDOZER_EFFECT_STANDARD_Y + 20,
       z: ARMDOZER_EFFECT_STANDARD_Z,
     };
     this.#group = new THREE.Group();

--- a/src/js/game-object/armdozer/gran-dozer/gran-dozer.ts
+++ b/src/js/game-object/armdozer/gran-dozer/gran-dozer.ts
@@ -53,6 +53,7 @@ export class GranDozer extends EmptyArmdozerSprite {
     super();
     this.#props = createGranDozerProps(options);
     this.statusIconPosition = this.#props.view.statusIconPosition;
+    this.predicatedDamagePosition = this.#props.view.predicatedDamagePosition;
     this.#unsubscribers = bindEventListeners({
       ...options,
       props: this.#props,

--- a/src/js/game-object/armdozer/gran-dozer/view/enemy-gran-dozer-view.ts
+++ b/src/js/game-object/armdozer/gran-dozer/view/enemy-gran-dozer-view.ts
@@ -11,6 +11,7 @@ export class EnemyGranDozerView extends PlayerGranDozerView {
   constructor(resources: Resources) {
     super(resources);
     this.statusIconPosition.x *= -1;
+    this.predicatedDamagePosition.x *= -1;
   }
 
   /** @override */

--- a/src/js/game-object/armdozer/gran-dozer/view/gran-dozer-view.ts
+++ b/src/js/game-object/armdozer/gran-dozer/view/gran-dozer-view.ts
@@ -1,12 +1,12 @@
 import * as THREE from "three";
 
-import { StatusIconPosition } from "../../armdozer-sprite";
+import { ArmdozerWorldCoordinate } from "../../armdozer-sprite";
 import { GranDozerModel } from "../model/gran-dozer-model";
 
 /** グランドーザービュー */
 export interface GranDozerView {
   /** ステータスアイコンの位置（ワールド座標） */
-  statusIconPosition: StatusIconPosition;
+  statusIconPosition: ArmdozerWorldCoordinate;
 
   /**
    * デストラクタ相当の処理

--- a/src/js/game-object/armdozer/gran-dozer/view/gran-dozer-view.ts
+++ b/src/js/game-object/armdozer/gran-dozer/view/gran-dozer-view.ts
@@ -7,6 +7,8 @@ import { GranDozerModel } from "../model/gran-dozer-model";
 export interface GranDozerView {
   /** ステータスアイコンの位置（ワールド座標） */
   statusIconPosition: ArmdozerWorldCoordinate;
+  /** 予測ダメージの位置（ワールド座標） */
+  predicatedDamagePosition: ArmdozerWorldCoordinate;
 
   /**
    * デストラクタ相当の処理

--- a/src/js/game-object/armdozer/gran-dozer/view/player-gran-dozer-view.ts
+++ b/src/js/game-object/armdozer/gran-dozer/view/player-gran-dozer-view.ts
@@ -16,6 +16,8 @@ import { GranDozerView } from "./gran-dozer-view";
 export class PlayerGranDozerView implements GranDozerView {
   /** @override */
   statusIconPosition: ArmdozerWorldCoordinate;
+  /** @override */
+  predicatedDamagePosition: ArmdozerWorldCoordinate;
   /** グループ */
   #group: THREE.Group;
   /** メッシュ */
@@ -29,6 +31,11 @@ export class PlayerGranDozerView implements GranDozerView {
     this.statusIconPosition = {
       x: ARMDOZER_EFFECT_STANDARD_X - 70,
       y: ARMDOZER_EFFECT_STANDARD_Y + 80,
+      z: ARMDOZER_EFFECT_STANDARD_Z,
+    };
+    this.predicatedDamagePosition = {
+      x: ARMDOZER_EFFECT_STANDARD_X - 50,
+      y: ARMDOZER_EFFECT_STANDARD_Y + 20,
       z: ARMDOZER_EFFECT_STANDARD_Z,
     };
     this.#group = new THREE.Group();

--- a/src/js/game-object/armdozer/gran-dozer/view/player-gran-dozer-view.ts
+++ b/src/js/game-object/armdozer/gran-dozer/view/player-gran-dozer-view.ts
@@ -6,7 +6,7 @@ import {
   ARMDOZER_EFFECT_STANDARD_Y,
   ARMDOZER_EFFECT_STANDARD_Z,
 } from "../../../td-position";
-import { StatusIconPosition } from "../../armdozer-sprite";
+import { ArmdozerWorldCoordinate } from "../../armdozer-sprite";
 import { createAllMeshes } from "../meshes";
 import { AnimationMesh } from "../meshes/animation-mesh";
 import { GranDozerModel } from "../model/gran-dozer-model";
@@ -15,7 +15,7 @@ import { GranDozerView } from "./gran-dozer-view";
 /** プレイヤー グランドーザービュー */
 export class PlayerGranDozerView implements GranDozerView {
   /** @override */
-  statusIconPosition: StatusIconPosition;
+  statusIconPosition: ArmdozerWorldCoordinate;
   /** グループ */
   #group: THREE.Group;
   /** メッシュ */

--- a/src/js/game-object/armdozer/lightning-dozer/lightning-dozer.ts
+++ b/src/js/game-object/armdozer/lightning-dozer/lightning-dozer.ts
@@ -58,6 +58,7 @@ export class LightningDozer
     const { gameObjectAction } = params;
     this.#props = createLightningDozerProps(params);
     this.statusIconPosition = this.#props.view.statusIconPosition;
+    this.predicatedDamagePosition = this.#props.view.predicatedDamagePosition;
     this.#unsubscribers = bindEventListeners({
       props: this.#props,
       gameObjectAction,

--- a/src/js/game-object/armdozer/lightning-dozer/view/enemy-lightning-dozer-view.ts
+++ b/src/js/game-object/armdozer/lightning-dozer/view/enemy-lightning-dozer-view.ts
@@ -13,6 +13,7 @@ export class EnemyLightningDozerView extends PlayerLightingDozerView {
   constructor(resources: Resources) {
     super(resources);
     this.statusIconPosition.x *= -1;
+    this.predicatedDamagePosition.x *= -1;
   }
 
   /**

--- a/src/js/game-object/armdozer/lightning-dozer/view/lightning-dozer-view.ts
+++ b/src/js/game-object/armdozer/lightning-dozer/view/lightning-dozer-view.ts
@@ -9,6 +9,8 @@ import { LightningDozerModel } from "../model/lightning-dozer-model";
 export interface LightningDozerView {
   /** ステータスアイコンの位置（ワールド座標） */
   statusIconPosition: ArmdozerWorldCoordinate;
+  /** 予測ダメージの位置（ワールド座標） */
+  predicatedDamagePosition: ArmdozerWorldCoordinate;
 
   /** デストラクタ相当の処理 */
   destructor(): void;

--- a/src/js/game-object/armdozer/lightning-dozer/view/lightning-dozer-view.ts
+++ b/src/js/game-object/armdozer/lightning-dozer/view/lightning-dozer-view.ts
@@ -1,6 +1,6 @@
 import * as THREE from "three";
 
-import { StatusIconPosition } from "../../armdozer-sprite";
+import { ArmdozerWorldCoordinate } from "../../armdozer-sprite";
 import { LightningDozerModel } from "../model/lightning-dozer-model";
 
 /**
@@ -8,7 +8,7 @@ import { LightningDozerModel } from "../model/lightning-dozer-model";
  */
 export interface LightningDozerView {
   /** ステータスアイコンの位置（ワールド座標） */
-  statusIconPosition: StatusIconPosition;
+  statusIconPosition: ArmdozerWorldCoordinate;
 
   /** デストラクタ相当の処理 */
   destructor(): void;

--- a/src/js/game-object/armdozer/lightning-dozer/view/player-lighting-dozer-view.ts
+++ b/src/js/game-object/armdozer/lightning-dozer/view/player-lighting-dozer-view.ts
@@ -16,6 +16,8 @@ import { LightningDozerView } from "./lightning-dozer-view";
 export class PlayerLightingDozerView implements LightningDozerView {
   /** @override */
   statusIconPosition: ArmdozerWorldCoordinate;
+  /** @override */
+  predicatedDamagePosition: ArmdozerWorldCoordinate;
   /** グループ */
   #group: THREE.Group;
   /** メッシュ */
@@ -29,6 +31,11 @@ export class PlayerLightingDozerView implements LightningDozerView {
     this.statusIconPosition = {
       x: ARMDOZER_EFFECT_STANDARD_X - 85,
       y: ARMDOZER_EFFECT_STANDARD_Y + 80,
+      z: ARMDOZER_EFFECT_STANDARD_Z,
+    };
+    this.predicatedDamagePosition = {
+      x: ARMDOZER_EFFECT_STANDARD_X - 50,
+      y: ARMDOZER_EFFECT_STANDARD_Y + 20,
       z: ARMDOZER_EFFECT_STANDARD_Z,
     };
     this.#group = new THREE.Group();

--- a/src/js/game-object/armdozer/lightning-dozer/view/player-lighting-dozer-view.ts
+++ b/src/js/game-object/armdozer/lightning-dozer/view/player-lighting-dozer-view.ts
@@ -6,7 +6,7 @@ import {
   ARMDOZER_EFFECT_STANDARD_Y,
   ARMDOZER_EFFECT_STANDARD_Z,
 } from "../../../td-position";
-import { StatusIconPosition } from "../../armdozer-sprite";
+import { ArmdozerWorldCoordinate } from "../../armdozer-sprite";
 import { createAllMeshes } from "../mesh";
 import { AnimationMesh } from "../mesh/animation-mesh";
 import { LightningDozerModel } from "../model/lightning-dozer-model";
@@ -15,7 +15,7 @@ import { LightningDozerView } from "./lightning-dozer-view";
 /** プレイヤー側のライトニングドーザビュー */
 export class PlayerLightingDozerView implements LightningDozerView {
   /** @override */
-  statusIconPosition: StatusIconPosition;
+  statusIconPosition: ArmdozerWorldCoordinate;
   /** グループ */
   #group: THREE.Group;
   /** メッシュ */

--- a/src/js/game-object/armdozer/neo-landozer/neo-landozer.ts
+++ b/src/js/game-object/armdozer/neo-landozer/neo-landozer.ts
@@ -55,6 +55,7 @@ export class NeoLandozer extends EmptyArmdozerSprite implements ArmdozerSprite {
     const { gameObjectAction } = params;
     this.#props = createNeoLandozerProps(params);
     this.statusIconPosition = this.#props.view.statusIconPosition;
+    this.predicatedDamagePosition = this.#props.view.predicatedDamagePosition;
     this.#unsubscribers = bindEventListeners({
       props: this.#props,
       gameObjectAction,

--- a/src/js/game-object/armdozer/neo-landozer/view/enemy-neo-landozer-view.ts
+++ b/src/js/game-object/armdozer/neo-landozer/view/enemy-neo-landozer-view.ts
@@ -14,6 +14,7 @@ export class EnemyNeoLandozerView extends PlayerNeoLandozerView {
   constructor(resources: Resources) {
     super(resources);
     this.statusIconPosition.x *= -1;
+    this.predicatedDamagePosition.x *= -1;
   }
 
   /** @override */

--- a/src/js/game-object/armdozer/neo-landozer/view/neo-landozer-view.ts
+++ b/src/js/game-object/armdozer/neo-landozer/view/neo-landozer-view.ts
@@ -7,6 +7,8 @@ import { NeoLandozerModel } from "../model/neo-landozer-model";
 export interface NeoLandozerView {
   /** ステータスアイコンの位置（ワールド座標） */
   statusIconPosition: ArmdozerWorldCoordinate;
+  /** ダメージ予想の位置（ワールド座標） */
+  predicatedDamagePosition: ArmdozerWorldCoordinate;
 
   /** デストラクタ */
   destructor(): void;

--- a/src/js/game-object/armdozer/neo-landozer/view/neo-landozer-view.ts
+++ b/src/js/game-object/armdozer/neo-landozer/view/neo-landozer-view.ts
@@ -1,12 +1,12 @@
 import * as THREE from "three";
 
-import { StatusIconPosition } from "../../armdozer-sprite";
+import { ArmdozerWorldCoordinate } from "../../armdozer-sprite";
 import { NeoLandozerModel } from "../model/neo-landozer-model";
 
 /** ネオランドーザのビュー */
 export interface NeoLandozerView {
   /** ステータスアイコンの位置（ワールド座標） */
-  statusIconPosition: StatusIconPosition;
+  statusIconPosition: ArmdozerWorldCoordinate;
 
   /** デストラクタ */
   destructor(): void;

--- a/src/js/game-object/armdozer/neo-landozer/view/player-neo-landozer-view.ts
+++ b/src/js/game-object/armdozer/neo-landozer/view/player-neo-landozer-view.ts
@@ -35,7 +35,7 @@ export class PlayerNeoLandozerView implements NeoLandozerView {
     };
     this.predicatedDamagePosition = {
       x: ARMDOZER_EFFECT_STANDARD_X - 50,
-      y: ARMDOZER_EFFECT_STANDARD_Y + 30,
+      y: ARMDOZER_EFFECT_STANDARD_Y + 20,
       z: ARMDOZER_EFFECT_STANDARD_Z,
     };
     this.#group = new THREE.Group();

--- a/src/js/game-object/armdozer/neo-landozer/view/player-neo-landozer-view.ts
+++ b/src/js/game-object/armdozer/neo-landozer/view/player-neo-landozer-view.ts
@@ -16,6 +16,8 @@ import { NeoLandozerView } from "./neo-landozer-view";
 export class PlayerNeoLandozerView implements NeoLandozerView {
   /** @override */
   statusIconPosition: ArmdozerWorldCoordinate;
+  /** @override */
+  predicatedDamagePosition: ArmdozerWorldCoordinate;
   /** グループ */
   #group: THREE.Group;
   /** メッシュ */
@@ -29,6 +31,11 @@ export class PlayerNeoLandozerView implements NeoLandozerView {
     this.statusIconPosition = {
       x: ARMDOZER_EFFECT_STANDARD_X - 100,
       y: ARMDOZER_EFFECT_STANDARD_Y + 80,
+      z: ARMDOZER_EFFECT_STANDARD_Z,
+    };
+    this.predicatedDamagePosition = {
+      x: ARMDOZER_EFFECT_STANDARD_X - 50,
+      y: ARMDOZER_EFFECT_STANDARD_Y + 30,
       z: ARMDOZER_EFFECT_STANDARD_Z,
     };
     this.#group = new THREE.Group();

--- a/src/js/game-object/armdozer/neo-landozer/view/player-neo-landozer-view.ts
+++ b/src/js/game-object/armdozer/neo-landozer/view/player-neo-landozer-view.ts
@@ -6,7 +6,7 @@ import {
   ARMDOZER_EFFECT_STANDARD_Y,
   ARMDOZER_EFFECT_STANDARD_Z,
 } from "../../../td-position";
-import { StatusIconPosition } from "../../armdozer-sprite";
+import { ArmdozerWorldCoordinate } from "../../armdozer-sprite";
 import { createAllMeshes } from "../mesh";
 import { AnimationMesh } from "../mesh/animation-mesh";
 import { NeoLandozerModel } from "../model/neo-landozer-model";
@@ -15,7 +15,7 @@ import { NeoLandozerView } from "./neo-landozer-view";
 /** プレイヤー側ネオランドーザのビュー */
 export class PlayerNeoLandozerView implements NeoLandozerView {
   /** @override */
-  statusIconPosition: StatusIconPosition;
+  statusIconPosition: ArmdozerWorldCoordinate;
   /** グループ */
   #group: THREE.Group;
   /** メッシュ */

--- a/src/js/game-object/armdozer/shin-braver/shin-braver.ts
+++ b/src/js/game-object/armdozer/shin-braver/shin-braver.ts
@@ -57,6 +57,7 @@ export class ShinBraver extends EmptyArmdozerSprite implements ArmdozerSprite {
     const { gameObjectAction } = params;
     this.#props = createShinBraverProps(params);
     this.statusIconPosition = this.#props.view.statusIconPosition;
+    this.predicatedDamagePosition = this.#props.view.predicatedDamagePosition;
     this.#unsubscribers = bindEventListeners({
       props: this.#props,
       gameObjectAction,

--- a/src/js/game-object/armdozer/shin-braver/view/enemy-shin-braver-view.ts
+++ b/src/js/game-object/armdozer/shin-braver/view/enemy-shin-braver-view.ts
@@ -14,6 +14,7 @@ export class EnemyShinBraverView extends PlayerShinBraverView {
   constructor(resources: Resources) {
     super(resources);
     this.statusIconPosition.x *= -1;
+    this.predicatedDamagePosition.x *= -1;
   }
 
   /** モデルをビューに反映させる */

--- a/src/js/game-object/armdozer/shin-braver/view/player-shin-braver-view.ts
+++ b/src/js/game-object/armdozer/shin-braver/view/player-shin-braver-view.ts
@@ -6,7 +6,7 @@ import {
   ARMDOZER_EFFECT_STANDARD_Y,
   ARMDOZER_EFFECT_STANDARD_Z,
 } from "../../../td-position";
-import { StatusIconPosition } from "../../armdozer-sprite";
+import { ArmdozerWorldCoordinate } from "../../armdozer-sprite";
 import { createAllMeshes } from "../mesh";
 import { AnimationMesh } from "../mesh/animation-mesh";
 import { ShinBraverModel } from "../model/shin-braver-model";
@@ -15,7 +15,7 @@ import { ShinBraverView } from "./shin-braver-view";
 /** プレイヤー側シンブレイバーのビュー */
 export class PlayerShinBraverView implements ShinBraverView {
   /** @override */
-  statusIconPosition: StatusIconPosition;
+  statusIconPosition: ArmdozerWorldCoordinate;
   /** グループ */
   #group: THREE.Group;
   /** メッシュ */

--- a/src/js/game-object/armdozer/shin-braver/view/player-shin-braver-view.ts
+++ b/src/js/game-object/armdozer/shin-braver/view/player-shin-braver-view.ts
@@ -16,6 +16,8 @@ import { ShinBraverView } from "./shin-braver-view";
 export class PlayerShinBraverView implements ShinBraverView {
   /** @override */
   statusIconPosition: ArmdozerWorldCoordinate;
+  /** @override */
+  predicatedDamagePosition: ArmdozerWorldCoordinate;
   /** グループ */
   #group: THREE.Group;
   /** メッシュ */
@@ -29,6 +31,11 @@ export class PlayerShinBraverView implements ShinBraverView {
     this.statusIconPosition = {
       x: ARMDOZER_EFFECT_STANDARD_X - 80,
       y: ARMDOZER_EFFECT_STANDARD_Y + 80,
+      z: ARMDOZER_EFFECT_STANDARD_Z,
+    };
+    this.predicatedDamagePosition = {
+      x: ARMDOZER_EFFECT_STANDARD_X - 50,
+      y: ARMDOZER_EFFECT_STANDARD_Y + 20,
       z: ARMDOZER_EFFECT_STANDARD_Z,
     };
     this.#group = new THREE.Group();

--- a/src/js/game-object/armdozer/shin-braver/view/shin-braver-view.ts
+++ b/src/js/game-object/armdozer/shin-braver/view/shin-braver-view.ts
@@ -1,12 +1,12 @@
 import * as THREE from "three";
 
-import { StatusIconPosition } from "../../armdozer-sprite";
+import { ArmdozerWorldCoordinate } from "../../armdozer-sprite";
 import { ShinBraverModel } from "../model/shin-braver-model";
 
 /** シンブレイバーのビュー */
 export interface ShinBraverView {
   /** ステータスアイコンの位置（ワールド座標） */
-  statusIconPosition: StatusIconPosition;
+  statusIconPosition: ArmdozerWorldCoordinate;
 
   /**
    * デストラクタ相当の処置

--- a/src/js/game-object/armdozer/shin-braver/view/shin-braver-view.ts
+++ b/src/js/game-object/armdozer/shin-braver/view/shin-braver-view.ts
@@ -7,6 +7,8 @@ import { ShinBraverModel } from "../model/shin-braver-model";
 export interface ShinBraverView {
   /** ステータスアイコンの位置（ワールド座標） */
   statusIconPosition: ArmdozerWorldCoordinate;
+  /** ダメージ予測の位置（ワールド座標） */
+  predicatedDamagePosition: ArmdozerWorldCoordinate;
 
   /**
    * デストラクタ相当の処置

--- a/src/js/game-object/armdozer/wing-dozer/view/enemy-wing-dozer-view.ts
+++ b/src/js/game-object/armdozer/wing-dozer/view/enemy-wing-dozer-view.ts
@@ -14,6 +14,7 @@ export class EnemyWingDozerView extends PlayerWingDozerView {
   constructor(resources: Resources) {
     super(resources);
     this.statusIconPosition.x *= -1;
+    this.predicatedDamagePosition.x *= -1;
   }
 
   /**

--- a/src/js/game-object/armdozer/wing-dozer/view/player-wing-dozer-view.ts
+++ b/src/js/game-object/armdozer/wing-dozer/view/player-wing-dozer-view.ts
@@ -17,6 +17,8 @@ import { WingDozerView } from "./wing-dozer-view";
 export class PlayerWingDozerView implements WingDozerView {
   /** @override */
   statusIconPosition: ArmdozerWorldCoordinate;
+  /** @override */
+  predicatedDamagePosition: ArmdozerWorldCoordinate;
 
   /** グループ */
   #group: THREE.Group;
@@ -32,6 +34,11 @@ export class PlayerWingDozerView implements WingDozerView {
     this.statusIconPosition = {
       x: ARMDOZER_EFFECT_STANDARD_X - 75,
       y: ARMDOZER_EFFECT_STANDARD_Y + 80,
+      z: ARMDOZER_EFFECT_STANDARD_Z,
+    };
+    this.predicatedDamagePosition = {
+      x: ARMDOZER_EFFECT_STANDARD_X - 50,
+      y: ARMDOZER_EFFECT_STANDARD_Y + 20,
       z: ARMDOZER_EFFECT_STANDARD_Z,
     };
     this.#group = new Group();

--- a/src/js/game-object/armdozer/wing-dozer/view/player-wing-dozer-view.ts
+++ b/src/js/game-object/armdozer/wing-dozer/view/player-wing-dozer-view.ts
@@ -7,7 +7,7 @@ import {
   ARMDOZER_EFFECT_STANDARD_Y,
   ARMDOZER_EFFECT_STANDARD_Z,
 } from "../../../td-position";
-import { StatusIconPosition } from "../../armdozer-sprite";
+import { ArmdozerWorldCoordinate } from "../../armdozer-sprite";
 import { createAllMeshes } from "../mesh";
 import { AnimationMesh } from "../mesh/animation-mesh";
 import { WingDozerModel } from "../model/wing-dozer-model";
@@ -16,7 +16,7 @@ import { WingDozerView } from "./wing-dozer-view";
 /** プレイヤー側 ウィングドーザ ビュー */
 export class PlayerWingDozerView implements WingDozerView {
   /** @override */
-  statusIconPosition: StatusIconPosition;
+  statusIconPosition: ArmdozerWorldCoordinate;
 
   /** グループ */
   #group: THREE.Group;

--- a/src/js/game-object/armdozer/wing-dozer/view/wing-dozer-view.ts
+++ b/src/js/game-object/armdozer/wing-dozer/view/wing-dozer-view.ts
@@ -7,6 +7,8 @@ import { WingDozerModel } from "../model/wing-dozer-model";
 export interface WingDozerView {
   /** ステータスアイコンの位置（ワールド座標） */
   statusIconPosition: ArmdozerWorldCoordinate;
+  /** 予測ダメージの位置（ワールド座標） */
+  predicatedDamagePosition: ArmdozerWorldCoordinate;
 
   /**
    * デストラクタ相当の処理

--- a/src/js/game-object/armdozer/wing-dozer/view/wing-dozer-view.ts
+++ b/src/js/game-object/armdozer/wing-dozer/view/wing-dozer-view.ts
@@ -1,12 +1,12 @@
 import * as THREE from "three";
 
-import { StatusIconPosition } from "../../armdozer-sprite";
+import { ArmdozerWorldCoordinate } from "../../armdozer-sprite";
 import { WingDozerModel } from "../model/wing-dozer-model";
 
 /**ウィングドーザ ビュー */
 export interface WingDozerView {
   /** ステータスアイコンの位置（ワールド座標） */
-  statusIconPosition: StatusIconPosition;
+  statusIconPosition: ArmdozerWorldCoordinate;
 
   /**
    * デストラクタ相当の処理

--- a/src/js/game-object/armdozer/wing-dozer/wing-dozer.ts
+++ b/src/js/game-object/armdozer/wing-dozer/wing-dozer.ts
@@ -55,6 +55,7 @@ export class WingDozer extends EmptyArmdozerSprite implements ArmdozerSprite {
     const { gameObjectAction } = params;
     this.#props = createWingDozerProps(params);
     this.statusIconPosition = this.#props.view.statusIconPosition;
+    this.predicatedDamagePosition = this.#props.view.predicatedDamagePosition;
     this.#unsubscribers = bindEventListeners({
       props: this.#props,
       gameObjectAction,

--- a/src/js/game-object/predicated-damage/view/predicated-damage-view.ts
+++ b/src/js/game-object/predicated-damage/view/predicated-damage-view.ts
@@ -142,7 +142,9 @@ export class PredicatedDamageView {
     this.#numbers.forEach((mesh, i) => {
       mesh.opacity(0);
       mesh.getObject3D().position.x =
-        (-i + intervalCount) * NUMBER_MESH_INTERVAL + NUMBER_TO_ICON_MARGIN;
+        (-i + intervalCount) * NUMBER_MESH_INTERVAL 
+        -(intervalCount + 1) * NUMBER_MESH_INTERVAL
+        - NUMBER_TO_ICON_MARGIN;
     });
 
     R.zip(this.#numbers, values)

--- a/src/js/game-object/predicated-damage/view/predicated-damage-view.ts
+++ b/src/js/game-object/predicated-damage/view/predicated-damage-view.ts
@@ -137,14 +137,13 @@ export class PredicatedDamageView {
       .split("")
       .reverse()
       .map((v) => Number(v));
-    // マイナス記号も含めた数字間隔数
-    const intervalCount = values.length + 1;
     this.#numbers.forEach((mesh, i) => {
       mesh.opacity(0);
       mesh.getObject3D().position.x =
-        //(-i + intervalCount) * NUMBER_MESH_INTERVAL
-        //-(intervalCount + 1) * NUMBER_MESH_INTERVAL
-        (-i - 1) * NUMBER_MESH_INTERVAL - NUMBER_TO_ICON_MARGIN;
+        model.battleSimulatorIconPosition === "left"
+          ? (-i + values.length + 1) * NUMBER_MESH_INTERVAL +
+            NUMBER_TO_ICON_MARGIN
+          : (-i - 1) * NUMBER_MESH_INTERVAL - NUMBER_TO_ICON_MARGIN;
     });
 
     R.zip(this.#numbers, values)

--- a/src/js/game-object/predicated-damage/view/predicated-damage-view.ts
+++ b/src/js/game-object/predicated-damage/view/predicated-damage-view.ts
@@ -137,6 +137,10 @@ export class PredicatedDamageView {
       .split("")
       .reverse()
       .map((v) => Number(v));
+    // マイナス記号も含めた数字間隔数
+    // 数字桁をnとすると、その間隔はn-1だが、マイナス記号がある場合はさらに+1されるので
+    //   n - 1 + 1 = n
+    // が正しい計算になる
     const intervalCount = values.length;
     this.#numbers.forEach((mesh, i) => {
       mesh.opacity(0);

--- a/src/js/game-object/predicated-damage/view/predicated-damage-view.ts
+++ b/src/js/game-object/predicated-damage/view/predicated-damage-view.ts
@@ -38,7 +38,7 @@ const MIN_DISPLAYABLE_DAMAGE = 0;
 const BATTLE_SIMULATOR_ICON_SIZE = 70;
 
 /** 数字とアイコンの間のマージン */
-const NUMBER_TO_ICON_MARGIN = 2;
+const NUMBER_TO_ICON_MARGIN = 16;
 
 /** バトルシミュレーターアイコンのY位置 */
 const BATTLE_SIMULATOR_ICON_Y = 2;
@@ -138,14 +138,12 @@ export class PredicatedDamageView {
       .reverse()
       .map((v) => Number(v));
     // マイナス記号も含めた数字間隔数
-    // 数字桁をnとすると、その間隔はn-1だが、マイナス記号がある場合はさらに+1されるので
-    //   n - 1 + 1 = n
-    // が正しい計算になる
-    const intervalCount = values.length;
+    const intervalCount = values.length + 1;
     this.#numbers.forEach((mesh, i) => {
       mesh.opacity(0);
-      mesh.getObject3D().position.x =
-        (-i + intervalCount / 2) * NUMBER_MESH_INTERVAL;
+      mesh.getObject3D().position.x = model.battleSimulatorIconPosition
+        ? (-i + intervalCount) * NUMBER_MESH_INTERVAL + NUMBER_TO_ICON_MARGIN
+        : (-i + intervalCount) * NUMBER_MESH_INTERVAL + NUMBER_TO_ICON_MARGIN;
     });
 
     R.zip(this.#numbers, values)
@@ -163,15 +161,6 @@ export class PredicatedDamageView {
       sign.opacity(opacity);
       sign.animate(10 / MAX_ANIMATION);
     }
-
-    // const battleSimulatorIconOffsetX =
-    //   (intervalCount / 2) * NUMBER_MESH_INTERVAL +
-    //   BATTLE_SIMULATOR_ICON_SIZE / 2 +
-    //   NUMBER_TO_ICON_MARGIN;
-    // const battleSimulatorIconX =
-    //   model.battleSimulatorIconPosition === "right"
-    //     ? battleSimulatorIconOffsetX
-    //     : -battleSimulatorIconOffsetX;
 
     this.#battleSimulatorIcon.getObject3D().position.x = 0;
     this.#battleSimulatorIcon.getObject3D().position.y =

--- a/src/js/game-object/predicated-damage/view/predicated-damage-view.ts
+++ b/src/js/game-object/predicated-damage/view/predicated-damage-view.ts
@@ -164,16 +164,16 @@ export class PredicatedDamageView {
       sign.animate(10 / MAX_ANIMATION);
     }
 
-    const battleSimulatorIconOffsetX =
-      (intervalCount / 2) * NUMBER_MESH_INTERVAL +
-      BATTLE_SIMULATOR_ICON_SIZE / 2 +
-      NUMBER_TO_ICON_MARGIN;
-    const battleSimulatorIconX =
-      model.battleSimulatorIconPosition === "right"
-        ? battleSimulatorIconOffsetX
-        : -battleSimulatorIconOffsetX;
+    // const battleSimulatorIconOffsetX =
+    //   (intervalCount / 2) * NUMBER_MESH_INTERVAL +
+    //   BATTLE_SIMULATOR_ICON_SIZE / 2 +
+    //   NUMBER_TO_ICON_MARGIN;
+    // const battleSimulatorIconX =
+    //   model.battleSimulatorIconPosition === "right"
+    //     ? battleSimulatorIconOffsetX
+    //     : -battleSimulatorIconOffsetX;
 
-    this.#battleSimulatorIcon.getObject3D().position.x = battleSimulatorIconX;
+    this.#battleSimulatorIcon.getObject3D().position.x = 0;
     this.#battleSimulatorIcon.getObject3D().position.y =
       BATTLE_SIMULATOR_ICON_Y;
     this.#battleSimulatorIcon
@@ -185,8 +185,7 @@ export class PredicatedDamageView {
       );
     this.#battleSimulatorIcon.opacity(opacity);
 
-    this.#battleSimulatorIconPushDetector.getObject3D().position.x =
-      battleSimulatorIconX;
+    this.#battleSimulatorIconPushDetector.getObject3D().position.x = 0;
     this.#battleSimulatorIconPushDetector.getObject3D().position.y =
       BATTLE_SIMULATOR_ICON_Y;
   }

--- a/src/js/game-object/predicated-damage/view/predicated-damage-view.ts
+++ b/src/js/game-object/predicated-damage/view/predicated-damage-view.ts
@@ -142,9 +142,9 @@ export class PredicatedDamageView {
     this.#numbers.forEach((mesh, i) => {
       mesh.opacity(0);
       mesh.getObject3D().position.x =
-        (-i + intervalCount) * NUMBER_MESH_INTERVAL 
-        -(intervalCount + 1) * NUMBER_MESH_INTERVAL
-        - NUMBER_TO_ICON_MARGIN;
+        //(-i + intervalCount) * NUMBER_MESH_INTERVAL
+        //-(intervalCount + 1) * NUMBER_MESH_INTERVAL
+        (-i - 1) * NUMBER_MESH_INTERVAL - NUMBER_TO_ICON_MARGIN;
     });
 
     R.zip(this.#numbers, values)

--- a/src/js/game-object/predicated-damage/view/predicated-damage-view.ts
+++ b/src/js/game-object/predicated-damage/view/predicated-damage-view.ts
@@ -141,9 +141,8 @@ export class PredicatedDamageView {
     const intervalCount = values.length + 1;
     this.#numbers.forEach((mesh, i) => {
       mesh.opacity(0);
-      mesh.getObject3D().position.x = model.battleSimulatorIconPosition
-        ? (-i + intervalCount) * NUMBER_MESH_INTERVAL + NUMBER_TO_ICON_MARGIN
-        : (-i + intervalCount) * NUMBER_MESH_INTERVAL + NUMBER_TO_ICON_MARGIN;
+      mesh.getObject3D().position.x =
+        (-i + intervalCount) * NUMBER_MESH_INTERVAL + NUMBER_TO_ICON_MARGIN;
     });
 
     R.zip(this.#numbers, values)

--- a/src/js/td-scenes/battle/view/procedure/tracking/predicated-damage-tracking.ts
+++ b/src/js/td-scenes/battle/view/procedure/tracking/predicated-damage-tracking.ts
@@ -6,8 +6,8 @@ import { TrackingParams } from "./tracking-params";
  * @param params パラメータ
  */
 export function predicatedDamageTracking(params: TrackingParams) {
-  const { td, hud, rendererDOM, playerId } = params;
-  hud.players.forEach(({ predicatedDamage }) => {
+  const { td, hud, rendererDOM } = params;
+  hud.players.forEach(({ playerId, predicatedDamage }) => {
     const armdozer = td.armdozers.find((a) => a.playerId === playerId);
     if (!armdozer) {
       return;

--- a/src/js/td-scenes/battle/view/procedure/tracking/predicated-damage-tracking.ts
+++ b/src/js/td-scenes/battle/view/procedure/tracking/predicated-damage-tracking.ts
@@ -1,57 +1,5 @@
-import * as THREE from "three";
-
-import { PredicatedDamage } from "../../../../../game-object/predicated-damage";
-import {
-  ARMDOZER_EFFECT_STANDARD_X,
-  ARMDOZER_EFFECT_STANDARD_Y,
-  ARMDOZER_EFFECT_STANDARD_Z,
-} from "../../../../../game-object/td-position";
 import { toHUDCoordinate } from "../../../../../tracking/to-hud-coordinate";
 import { TrackingParams } from "./tracking-params";
-
-/** ダメージ予想 トラッキング パラメータ */
-type PredicatedDamageTrackingParams = {
-  /** ダメージ予想 */
-  predicatedDamage: PredicatedDamage;
-  /** 3Dレイヤーカメラ */
-  tdCamera: THREE.PerspectiveCamera;
-  /** レンダラのHTML要素 */
-  rendererDOM: HTMLElement;
-};
-
-/**
- * ダメージ予想のトラッキング（プレイヤー側）
- * @param params パラメータ
- */
-function playerPredicatedDamageTracking(
-  params: PredicatedDamageTrackingParams,
-) {
-  const { predicatedDamage, tdCamera, rendererDOM } = params;
-  const origin = {
-    x: ARMDOZER_EFFECT_STANDARD_X - 30,
-    y: ARMDOZER_EFFECT_STANDARD_Y,
-    z: ARMDOZER_EFFECT_STANDARD_Z,
-  };
-  const hudCoordinate = toHUDCoordinate(origin, tdCamera, rendererDOM);
-  predicatedDamage.getObject3D().position.x = hudCoordinate.x;
-  predicatedDamage.getObject3D().position.y = hudCoordinate.y;
-}
-
-/**
- * ダメージ予想のトラッキング（敵側）
- * @param params パラメータ
- */
-function enemyPredicatedDamageTracking(params: PredicatedDamageTrackingParams) {
-  const { predicatedDamage, tdCamera, rendererDOM } = params;
-  const origin = {
-    x: -ARMDOZER_EFFECT_STANDARD_X + 30,
-    y: ARMDOZER_EFFECT_STANDARD_Y,
-    z: ARMDOZER_EFFECT_STANDARD_Z,
-  };
-  const hudCoordinate = toHUDCoordinate(origin, tdCamera, rendererDOM);
-  predicatedDamage.getObject3D().position.x = hudCoordinate.x;
-  predicatedDamage.getObject3D().position.y = hudCoordinate.y;
-}
 
 /**
  * 予想ダメージのトラッキング
@@ -59,17 +7,19 @@ function enemyPredicatedDamageTracking(params: PredicatedDamageTrackingParams) {
  */
 export function predicatedDamageTracking(params: TrackingParams) {
   const { td, hud, rendererDOM, playerId } = params;
-  hud.players.forEach(({ playerId: currentPlayerId, predicatedDamage }) => {
-    const isPlayer = currentPlayerId === playerId;
-    const trackingParams = {
-      tdCamera: td.camera.getCamera(),
-      rendererDOM,
-      predicatedDamage,
-    };
-    if (isPlayer) {
-      playerPredicatedDamageTracking(trackingParams);
-    } else {
-      enemyPredicatedDamageTracking(trackingParams);
+  hud.players.forEach(({ predicatedDamage }) => {
+    const armdozer = td.armdozers.find((a) => a.playerId === playerId);
+    if (!armdozer) {
+      return;
     }
+
+    const origin = armdozer.sprite().predicatedDamagePosition;
+    const hudCoordinate = toHUDCoordinate(
+      origin,
+      td.camera.getCamera(),
+      rendererDOM,
+    );
+    predicatedDamage.getObject3D().position.x = hudCoordinate.x;
+    predicatedDamage.getObject3D().position.y = hudCoordinate.y;
   });
 }

--- a/src/js/td-scenes/battle/view/procedure/tracking/predicated-damage-tracking.ts
+++ b/src/js/td-scenes/battle/view/procedure/tracking/predicated-damage-tracking.ts
@@ -28,7 +28,7 @@ function playerPredicatedDamageTracking(
 ) {
   const { predicatedDamage, tdCamera, rendererDOM } = params;
   const origin = {
-    x: ARMDOZER_EFFECT_STANDARD_X - 150,
+    x: ARMDOZER_EFFECT_STANDARD_X - 100,
     y: ARMDOZER_EFFECT_STANDARD_Y,
     z: ARMDOZER_EFFECT_STANDARD_Z,
   };
@@ -44,7 +44,7 @@ function playerPredicatedDamageTracking(
 function enemyPredicatedDamageTracking(params: PredicatedDamageTrackingParams) {
   const { predicatedDamage, tdCamera, rendererDOM } = params;
   const origin = {
-    x: -ARMDOZER_EFFECT_STANDARD_X + 150,
+    x: -ARMDOZER_EFFECT_STANDARD_X + 100,
     y: ARMDOZER_EFFECT_STANDARD_Y,
     z: ARMDOZER_EFFECT_STANDARD_Z,
   };

--- a/src/js/td-scenes/battle/view/procedure/tracking/predicated-damage-tracking.ts
+++ b/src/js/td-scenes/battle/view/procedure/tracking/predicated-damage-tracking.ts
@@ -28,7 +28,7 @@ function playerPredicatedDamageTracking(
 ) {
   const { predicatedDamage, tdCamera, rendererDOM } = params;
   const origin = {
-    x: ARMDOZER_EFFECT_STANDARD_X - 100,
+    x: ARMDOZER_EFFECT_STANDARD_X - 30,
     y: ARMDOZER_EFFECT_STANDARD_Y,
     z: ARMDOZER_EFFECT_STANDARD_Z,
   };
@@ -44,7 +44,7 @@ function playerPredicatedDamageTracking(
 function enemyPredicatedDamageTracking(params: PredicatedDamageTrackingParams) {
   const { predicatedDamage, tdCamera, rendererDOM } = params;
   const origin = {
-    x: -ARMDOZER_EFFECT_STANDARD_X + 100,
+    x: -ARMDOZER_EFFECT_STANDARD_X + 30,
     y: ARMDOZER_EFFECT_STANDARD_Y,
     z: ARMDOZER_EFFECT_STANDARD_Z,
   };


### PR DESCRIPTION
This pull request extends the Armdozer sprite and view system to support a new coordinate for displaying predicted damage in addition to the existing status icon position. It introduces a unified type for world coordinates, updates all related interfaces and classes, and ensures that both player and enemy sprites handle the new coordinate correctly.

**Core API and Type Changes:**

* Introduced a new type `ArmdozerWorldCoordinate` to replace the previous `StatusIconPosition`, unifying coordinate representation for Armdozer-related positions. (`src/js/game-object/armdozer/armdozer-sprite.ts` [src/js/game-object/armdozer/armdozer-sprite.tsL5-R6](diffhunk://#diff-38e214411cda8a2390e877fdeb00df5ce52aa2a83caf80e9cbc7f5a330841227L5-R6))
* Updated all Armdozer view interfaces (`GenesisBraverView`, `GranDozerView`, `LightningDozerView`, `NeoLandozerView`) to use `ArmdozerWorldCoordinate` for both `statusIconPosition` and the new `predicatedDamagePosition`. (`src/js/game-object/armdozer/genesis-braver/view/genesis-braver-view.ts` [[1]](diffhunk://#diff-3a9efaa6513cf792436e84dd7e69b0ac16c8657fb98b416aef5e51b883c4f601L3-R11) `src/js/game-object/armdozer/gran-dozer/view/gran-dozer-view.ts` [[2]](diffhunk://#diff-23500a9ac4d36516d7535abc3f4842b5847da51b08328407eb47ff4d50aaef81L3-R11) `src/js/game-object/armdozer/lightning-dozer/view/lightning-dozer-view.ts` [[3]](diffhunk://#diff-374b1f9a44c43f11073ff31abe93e6f643b9b00cb66895c0e141f97c429018d6L3-R13) `src/js/game-object/armdozer/neo-landozer/view/neo-landozer-view.ts` [[4]](diffhunk://#diff-50da2f4dfcc44a0fb0b0713eba79f0873fe9bbeb9cc613ec22df4ad146efdceeL3-R11)

**Implementation Updates for Sprites and Views:**

* Added `predicatedDamagePosition` to all Armdozer sprite implementations (including `EmptyArmdozerSprite`, `GenesisBraver`, `GranDozer`, `LightningDozer`, `NeoLandozer`, `ShinBraver`) and ensured it is initialized from the respective view's properties. (`src/js/game-object/armdozer/empty-armdozer-sprite.ts` [[1]](diffhunk://#diff-8d62dbcf31bd29034db0036e9d39d97dd4c7386e1410671e9637243603055608R23-R28) `src/js/game-object/armdozer/genesis-braver/genesis-braver.ts` [[2]](diffhunk://#diff-18443b9d11f1b2087292a49b63c4f73a2db87d747b14f729861ee344a2f26e83R61) `src/js/game-object/armdozer/gran-dozer/gran-dozer.ts` [[3]](diffhunk://#diff-22b5181371dfe926d0d89d8913d8f0f4e2fe5e4a2c744b6168d143dccaf9f7e6R56) `src/js/game-object/armdozer/lightning-dozer/lightning-dozer.ts` [[4]](diffhunk://#diff-7f3e3b405b18706d3c0915fd852d644f9889f65a938094a559cfa204d23e1647R61) `src/js/game-object/armdozer/neo-landozer/neo-landozer.ts` [[5]](diffhunk://#diff-8a15d3e412812a53e5af7cd363ef322329bc46bc1bf46106b919da22d7bdb0e8R58) `src/js/game-object/armdozer/shin-braver/shin-braver.ts` [[6]](diffhunk://#diff-49ea34ce2755e41186aa24c04b87181e4dde83704d0960a285b429419c975b82R60)
* Updated player view classes for all Armdozer types to initialize `predicatedDamagePosition` with appropriate coordinates. (`src/js/game-object/armdozer/genesis-braver/view/player-genesis-braver-view.ts` [[1]](diffhunk://#diff-6dd0e479a33e55ad3e7ee3580095060abb54e7d261b293231fe7f28f7c44fae1L18-R20) [[2]](diffhunk://#diff-6dd0e479a33e55ad3e7ee3580095060abb54e7d261b293231fe7f28f7c44fae1R36-R40); `src/js/game-object/armdozer/gran-dozer/view/player-gran-dozer-view.ts` [[3]](diffhunk://#diff-7328a0ce3a191fc186d5e83802611ea4c589dde05f7f4210b10fe66175e5bd8cL18-R20) [[4]](diffhunk://#diff-7328a0ce3a191fc186d5e83802611ea4c589dde05f7f4210b10fe66175e5bd8cR36-R40); `src/js/game-object/armdozer/lightning-dozer/view/player-lighting-dozer-view.ts` [[5]](diffhunk://#diff-b7c25dd26a6ff42ae46d76e838ed8444fac3cf1998bd36319f2472c25f8eaf4fL18-R20) [[6]](diffhunk://#diff-b7c25dd26a6ff42ae46d76e838ed8444fac3cf1998bd36319f2472c25f8eaf4fR36-R40); `src/js/game-object/armdozer/neo-landozer/view/player-neo-landozer-view.ts` [[7]](diffhunk://#diff-6e054d7e63b421606c544ac6ca84b04c1a05f3915ca82ee0982cf10a91075dd0L18-R20) [[8]](diffhunk://#diff-6e054d7e63b421606c544ac6ca84b04c1a05f3915ca82ee0982cf10a91075dd0R36-R40)

**Enemy View Adjustments:**

* Ensured all enemy Armdozer view classes invert the `x` coordinate of `predicatedDamagePosition` (mirroring the behavior for `statusIconPosition`) for correct display orientation. (`src/js/game-object/armdozer/genesis-braver/view/enemy-genesis-braver-view.ts` [[1]](diffhunk://#diff-603639dd2a0fe2c6100357e5671121cda88fef9649caba7fec2e27ce12d7f8b4R14) `src/js/game-object/armdozer/gran-dozer/view/enemy-gran-dozer-view.ts` [[2]](diffhunk://#diff-e87cb0773f8441b4bbabca9e2a59edd6954557eed84832bb75596cda9d172e4aR14) `src/js/game-object/armdozer/lightning-dozer/view/enemy-lightning-dozer-view.ts` [[3]](diffhunk://#diff-35e44d71592f437ca6a95aab9d93ab4987de7b21f903828f912425a4feab15bdR16) `src/js/game-object/armdozer/neo-landozer/view/enemy-neo-landozer-view.ts` [[4]](diffhunk://#diff-bfb1778b35e0b7efe40d6051a3ce3f1d107d6cf6778e1d9bc81764820a578a58R17) `src/js/game-object/armdozer/shin-braver/view/enemy-shin-braver-view.ts` [[5]](diffhunk://#diff-221fb36f01a4b31d4b924fc91a3ca7c7b72e9b3278a31eb56d0db23375bccb08R17)

**Imports and Type References:**

* Updated all relevant imports and type references from `StatusIconPosition` to `ArmdozerWorldCoordinate` throughout the codebase to maintain consistency and type safety. (`src/js/game-object/armdozer/genesis-braver/view/player-genesis-braver-view.ts` [[1]](diffhunk://#diff-6dd0e479a33e55ad3e7ee3580095060abb54e7d261b293231fe7f28f7c44fae1L9-R9) `src/js/game-object/armdozer/gran-dozer/view/player-gran-dozer-view.ts` [[2]](diffhunk://#diff-7328a0ce3a191fc186d5e83802611ea4c589dde05f7f4210b10fe66175e5bd8cL9-R9) `src/js/game-object/armdozer/lightning-dozer/view/player-lighting-dozer-view.ts` [[3]](diffhunk://#diff-b7c25dd26a6ff42ae46d76e838ed8444fac3cf1998bd36319f2472c25f8eaf4fL9-R9) `src/js/game-object/armdozer/neo-landozer/view/player-neo-landozer-view.ts` [[4]](diffhunk://#diff-6e054d7e63b421606c544ac6ca84b04c1a05f3915ca82ee0982cf10a91075dd0L9-R9)

These changes collectively introduce a new, standardized way to manage world coordinates for Armdozer sprites and views, enabling new UI features such as predicted damage indicators while keeping the codebase clean and consistent.