### PR TITLE
プライベートマッチ、あいことば対戦のパスワードが翻訳されないようにした

### DIFF
--- a/src/js/dom-dialogs/local-battle-host/dom/root-inner-html.hbs
+++ b/src/js/dom-dialogs/local-battle-host/dom/root-inner-html.hbs
@@ -6,6 +6,6 @@
     data-id="closer"
   />
   <div class="{{ROOT_CLASS}}__password-label">あいことば</div>
-  <div class="{{ROOT_CLASS}}__password-value">{{password}}</div>
+  <div class="{{ROOT_CLASS}}__password-value" translate="no">{{password}}</div>
   <div class="{{ROOT_CLASS}}__wait-input">……あいてを待っています。</div>
 </div>

--- a/src/js/dom-dialogs/private-match-host/dom/root-inner-html.hbs
+++ b/src/js/dom-dialogs/private-match-host/dom/root-inner-html.hbs
@@ -14,7 +14,7 @@
     <div
       class="{{ROOT_CLASS}}__room-id-description"
     >ルームIDを共有してプライベートマッチ開始</div>
-    <div class="{{ROOT_CLASS}}__room-id-value">
+    <div class="{{ROOT_CLASS}}__room-id-value" translate="no">
       {{roomID}}
     </div>
     <button class="{{ROOT_CLASS}}__copy-room-id" data-id="copy-room-id">


### PR DESCRIPTION
This pull request makes small but important improvements to the UI by preventing unwanted automatic translation of sensitive or technical information. Specifically, it updates two dialog templates to mark certain fields as non-translatable.

UI improvements to prevent unwanted translation:

* Added `translate="no"` to the `{{password}}` field in `dom/root-inner-html.hbs` for the local battle host dialog, ensuring the password is not automatically translated by browsers or translation tools.
* Added `translate="no"` to the `{{roomID}}` field in `dom/root-inner-html.hbs` for the private match host dialog, preventing the room ID from being translated.