### PR TITLE
fix: update matching instructions for battle start

### DIFF
--- a/src/js/dom-dialogs/private-match-guest/dom/root-inner-html.hbs
+++ b/src/js/dom-dialogs/private-match-guest/dom/root-inner-html.hbs
@@ -15,17 +15,17 @@
   >マッチング失敗</div>
   <div
     class="{{ROOT_CLASS}}__qr-code-description"
-  >QRコードを読み込んでプライベートマッチ開始</div>
+  >QRコードを読み込んでバトル開始</div>
   <button
     class="{{ROOT_CLASS}}__start-qr-code-reader"
     data-id="start-qr-code-reader"
   >
-    カメラを起動
+    📷カメラを起動
   </button>
   <div class="{{ROOT_CLASS}}__separator">or</div>
   <div
     class="{{ROOT_CLASS}}__room-id-description"
-  >ルームIDを入力してプライベートマッチ開始</div>
+  >ルームIDを入力してバトル開始</div>
   <div class="{{ROOT_CLASS}}__room-id-form">
     <input
       class="{{ROOT_CLASS}}__room-id"

--- a/src/js/dom-dialogs/private-match-host/dom/root-inner-html.hbs
+++ b/src/js/dom-dialogs/private-match-host/dom/root-inner-html.hbs
@@ -7,13 +7,13 @@
   />
   <div
     class="{{ROOT_CLASS}}__qr-code-description"
-  >QRコードを共有してプライベートマッチ開始</div>
+  >QRコードを共有してバトル開始</div>
   <img alt="QRコード" class="{{ROOT_CLASS}}__qr-code" data-id="qr-code" />
   <div class="{{ROOT_CLASS}}__separator">or</div>
   <div class="{{ROOT_CLASS}}__room-id">
     <div
       class="{{ROOT_CLASS}}__room-id-description"
-    >ルームIDを共有してプライベートマッチ開始</div>
+    >ルームIDを共有してバトル開始</div>
     <div class="{{ROOT_CLASS}}__room-id-value" translate="no">
       {{roomID}}
     </div>


### PR DESCRIPTION
This pull request updates user-facing text in the private match dialogs to use more concise and engaging language for starting battles, and adds a camera emoji to the camera activation button for improved clarity.

**User Interface Text Updates:**

* Changed descriptions from "プライベートマッチ開始" ("start private match") to "バトル開始" ("start battle") in both guest and host QR code and room ID sections in `root-inner-html.hbs` templates. [[1]](diffhunk://#diff-490a375bf9a2e2fe2e0f314237aac2a9ce4d7f47f2af4cccd613500881840bccL18-R28) [[2]](diffhunk://#diff-7871fbdeed6a787a3dc0485b2fc618d1946c97c2e0df409d4c4b37c29e354db7L10-R16)
* Added a camera emoji (📷) to the "カメラを起動" ("start camera") button to make its purpose clearer in the guest dialog.