### PR TITLE
あいことば対戦サーバーへのCloudFront追加にブラウザ側も対応

### DIFF
--- a/buildspec.prod.yml
+++ b/buildspec.prod.yml
@@ -28,7 +28,7 @@ env:
     COGNITO_USER_POOL_ID: /GbraverBurst/prod/cognitoUserPoolId
     COGNITO_CLIENT_ID: /GbraverBurst/prod/cognitoClientId
     COGNITO_HOSTED_UI_DOMAIN: /GbraverBurst/prod/cognitoHostedUIDomain
-    # WEBRTC_HELPER_DOMAIN_NAME: /GbraverBurst/prod/webrtcHelperDomainName #あいことば対戦正式リリースまでコメントアウトする
+    # BACKEND_CLOUDFRONT_DOMAIN_NAME: /GbraverBurst/prod/backendCloudFrontDomainName #あいことば対戦正式リリースまでコメントアウトする
     # COTURN_DOMAIN_NAME: /GbraverBurst/prod/coturnDomainName #あいことば対戦正式リリースまでコメントアウトする
 phases:
   install:
@@ -41,6 +41,6 @@ phases:
     commands:
       - export WEBSOCKET_API_URL="wss://${STAGE}.${WS_API_DOMAIN_NAME}"
       # - export SIGNAL_SERVER_URL="wss://${STAGE}.${WS_SIGNAL_DOMAIN_NAME}" #あいことば対戦正式リリースまでコメントアウトする
-      # - export WEBRTC_HELPER_API_URL="https://${STAGE}.${WEBRTC_HELPER_DOMAIN_NAME}" #あいことば対戦正式リリースまでコメントアウトする
+      # - export WEBRTC_HELPER_API_URL="https://${BACKEND_CLOUDFRONT_DOMAIN_NAME}/${STAGE}" #あいことば対戦正式リリースまでコメントアウトする
       - ./deploy.bash "${S3_BUCKET}" "${STAGE}" "${ASSETLINKS_JSON_URI}"
       - ./clear-cdn.bash "${DISTRIBUTION_ID}"

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -28,7 +28,7 @@ env:
     COGNITO_USER_POOL_ID: /GbraverBurst/dev/cognitoUserPoolId
     COGNITO_CLIENT_ID: /GbraverBurst/dev/cognitoClientId
     COGNITO_HOSTED_UI_DOMAIN: /GbraverBurst/dev/cognitoHostedUIDomain
-    WEBRTC_HELPER_DOMAIN_NAME: /GbraverBurst/dev/webrtcHelperDomainName
+    BACKEND_CLOUDFRONT_DOMAIN_NAME: /GbraverBurst/dev/backendCloudFrontDomainName
     COTURN_DOMAIN_NAME: /GbraverBurst/dev/coturnDomainName
 phases:
   install:
@@ -41,6 +41,6 @@ phases:
     commands:
       - export WEBSOCKET_API_URL="wss://${STAGE}.${WS_API_DOMAIN_NAME}"
       - export SIGNAL_SERVER_URL="wss://${STAGE}.${WS_SIGNAL_DOMAIN_NAME}"
-      - export WEBRTC_HELPER_API_URL="https://${STAGE}.${WEBRTC_HELPER_DOMAIN_NAME}"
+      - export WEBRTC_HELPER_API_URL="https://${BACKEND_CLOUDFRONT_DOMAIN_NAME}/${STAGE}"
       - ./deploy.bash "${S3_BUCKET}" "${STAGE}" "${ASSETLINKS_JSON_URI}"
       - ./clear-cdn.bash "${DISTRIBUTION_ID}"


### PR DESCRIPTION
…ldspec
This pull request updates the build configuration to switch from using the `WEBRTC_HELPER_DOMAIN_NAME` environment variable to `BACKEND_CLOUDFRONT_DOMAIN_NAME` for both development and production environments. This change also updates how the `WEBRTC_HELPER_API_URL` is constructed, now routing it through CloudFront and including the stage in the URL path.

**Build configuration updates:**

* Replaced the `WEBRTC_HELPER_DOMAIN_NAME` environment variable with `BACKEND_CLOUDFRONT_DOMAIN_NAME` in both `buildspec.yml` (development) and `buildspec.prod.yml` (production). [[1]](diffhunk://#diff-69387ac97f1b775f19989fc28150f89e785406cbff04643a969f5e396573dd5cL31-R31) [[2]](diffhunk://#diff-95a4779a60c8981757068733208a2aeb744c9097412aa27da62fbd0b6442e8caL31-R31)
* Updated the `WEBRTC_HELPER_API_URL` export command to use the new `BACKEND_CLOUDFRONT_DOMAIN_NAME` variable and include the stage in the URL path, instead of using the previous domain name format. [[1]](diffhunk://#diff-69387ac97f1b775f19989fc28150f89e785406cbff04643a969f5e396573dd5cL44-R44) [[2]](diffhunk://#diff-95a4779a60c8981757068733208a2aeb744c9097412aa27da62fbd0b6442e8caL44-R44)