### PR TITLE
gbraver-burst-coreをアップデート

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@gbraver-burst-network/local-webrtc-browser-sdk": "1.25.2",
         "@gbraver-burst-network/offline-browser-sdk": "1.25.2",
         "@tweenjs/tween.js": "^25.0.0",
-        "gbraver-burst-core": "1.44.0",
+        "gbraver-burst-core": "1.45.0",
         "handlebars": "^4.7.9",
         "howler": "^2.2.4",
         "jsqr": "^1.4.0",
@@ -13220,9 +13220,9 @@
       }
     },
     "node_modules/gbraver-burst-core": {
-      "version": "1.44.0",
-      "resolved": "https://registry.npmjs.org/gbraver-burst-core/-/gbraver-burst-core-1.44.0.tgz",
-      "integrity": "sha512-yk6oIFhpCJO8S1A0zCV7AY7CiJXvga2J3xkFZo4IF3Ktt1cOe9ZUGRZAaIHbPNM9WbNheAJ5HtNgsspg/n2fAQ==",
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/gbraver-burst-core/-/gbraver-burst-core-1.45.0.tgz",
+      "integrity": "sha512-NKGUkIjon7O/mxdCoaoeR5O5AN5O3vD3wcXisz3ARU6l4xBeaCXCMwJsf9wTNS8ujtZUQREOT3CcQT2nH8Y9ig==",
       "license": "MIT",
       "dependencies": {
         "ramda": "^0.32.0"
@@ -13231,7 +13231,7 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "zod": "^4.3.6"
+        "zod": "^4.4.3"
       }
     },
     "node_modules/gensync": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@gbraver-burst-network/local-webrtc-browser-sdk": "1.25.2",
     "@gbraver-burst-network/offline-browser-sdk": "1.25.2",
     "@tweenjs/tween.js": "^25.0.0",
-    "gbraver-burst-core": "1.44.0",
+    "gbraver-burst-core": "1.45.0",
     "handlebars": "^4.7.9",
     "howler": "^2.2.4",
     "jsqr": "^1.4.0",


### PR DESCRIPTION
This pull request updates the `gbraver-burst-core` dependency to a newer version in the `package.json` file. This is a minor change that ensures the project uses the latest features and fixes from the core library.