### PR TITLE
config.jsonを追加した

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -39,7 +39,7 @@ IS_SERVICE_WORKER_USED=false
 #   STANDALONE - ネットワーク系機能を完全に使わない
 #   OFFLINE_LAN - オフライン用イントラネット
 #   ONLINE - インターネット接続可能なサーバー（デフォルト）
-# 注意：config.jsonでcan-network-featuresをfalseにしている場合、
+# 注意：config.jsonでisBackendServerAvailableをfalseにしている場合、
 #      ネットワークモードは強制的にSTANDALONEになります
 NETWORK_MODE=ONLINE
 

--- a/.env.template
+++ b/.env.template
@@ -39,6 +39,8 @@ IS_SERVICE_WORKER_USED=false
 #   STANDALONE - ネットワーク系機能を完全に使わない
 #   OFFLINE_LAN - オフライン用イントラネット
 #   ONLINE - インターネット接続可能なサーバー（デフォルト）
+# 注意：config.jsonでcan-network-featuresをfalseにしている場合、
+#      ネットワークモードは強制的にSTANDALONEになります
 NETWORK_MODE=ONLINE
 
 # Websocket API URL

--- a/src/config.json
+++ b/src/config.json
@@ -1,3 +1,3 @@
 {
-  "can-network-features": true
+  "canNetWorkFeatures": true
 }

--- a/src/config.json
+++ b/src/config.json
@@ -1,3 +1,3 @@
 {
-  "canNetWorkFeatures": true
+  "isBackendServerAvailable": true
 }

--- a/src/config.json
+++ b/src/config.json
@@ -1,0 +1,3 @@
+{
+  "can-network-features": true
+}

--- a/src/js/config-json.ts
+++ b/src/js/config-json.ts
@@ -5,12 +5,16 @@ import { z } from "zod";
  * リリース後のアプリ挙動を手軽に変更するために利用する
  */
 export type ConfigJSON = {
-  canNetWorkFeatures: boolean;
+  /**
+   * バックエンドサーバーが利用可能かどうか
+   * trueの場合、バックエンドサーバーが利用可能である
+   */
+  isBackendServerAvailable: boolean;
 };
 
 /** ConfigJSON zod スキーマ */
 export const ConfigJSONSchema = z.object({
-  canNetWorkFeatures: z.boolean(),
+  isBackendServerAvailable: z.boolean(),
 });
 
 /**

--- a/src/js/config-json.ts
+++ b/src/js/config-json.ts
@@ -5,12 +5,12 @@ import { z } from "zod";
  * リリース後のアプリ挙動を手軽に変更するために利用する
  */
 export type ConfigJSON = {
-  "can-network-features": boolean;
+  canNetWorkFeatures: boolean;
 };
 
 /** ConfigJSON zod スキーマ */
 export const ConfigJSONSchema = z.object({
-  "can-network-features": z.boolean(),
+  canNetWorkFeatures: z.boolean(),
 });
 
 /**

--- a/src/js/config-json.ts
+++ b/src/js/config-json.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+
+/**
+ * config.jsonのデータ型
+ * リリース後のアプリ挙動を手軽に変更するために利用する
+ */
+export type ConfigJSON = {
+  "can-network-features": boolean;
+};
+
+/** ConfigJSON zod スキーマ */
+export const ConfigJSONSchema = z.object({
+  "can-network-features": z.boolean(),
+});
+
+/**
+ * config.jsonを取得する
+ * @returns 取得結果
+ */
+export const fetchConfigJSON = async (): Promise<ConfigJSON> => {
+  const response = await fetch("config.json");
+  const json = await response.json();
+  return ConfigJSONSchema.parse(json);
+};

--- a/src/js/main.ts
+++ b/src/js/main.ts
@@ -2,6 +2,7 @@ import "../css/style.css";
 
 import * as THREE from "three";
 
+import { ConfigJSON, fetchConfigJSON } from "./config-json";
 import { isMobile } from "./device-ditect/is-mobile";
 import { Game } from "./game";
 import { createLocalStorageConfigRepository } from "./game/config/repository/local-storage";
@@ -45,10 +46,16 @@ THREE.ColorManagement.enabled = false;
 
 /**
  * ネットワークコンテキストを作成する
+ * @param configJSON config.jsonの内容
  * @returns ネットワークコンテキスト
  */
-async function createNetworkContext(): Promise<NetworkContext> {
-  switch (GBRAVER_BURST_NETWORK_MODE) {
+async function createNetworkContext(
+  configJSON: ConfigJSON,
+): Promise<NetworkContext> {
+  const networkMode = configJSON.canNetWorkFeatures
+    ? GBRAVER_BURST_NETWORK_MODE
+    : "STANDALONE";
+  switch (networkMode) {
     case "ONLINE":
       return await createOnlineContext({
         canBeta: GBRAVER_BURST_CAN_ONLINE_BETA === "true",
@@ -72,7 +79,8 @@ async function createNetworkContext(): Promise<NetworkContext> {
  * Gブレイバーバーストのエントリポイント
  */
 export async function main(): Promise<void> {
-  const networkContext = await createNetworkContext();
+  const configJSON = await fetchConfigJSON();
+  const networkContext = await createNetworkContext(configJSON);
   const resourceRoot = isMobile() ? mobileResourceRoot : desktopResourceRoot;
   const webglPowerPreference = isMobile() ? "low-power" : "high-performance";
   const game = new Game({

--- a/src/js/main.ts
+++ b/src/js/main.ts
@@ -52,7 +52,7 @@ THREE.ColorManagement.enabled = false;
 async function createNetworkContext(
   configJSON: ConfigJSON,
 ): Promise<NetworkContext> {
-  const networkMode = configJSON.canNetWorkFeatures
+  const networkMode = configJSON.isBackendServerAvailable
     ? GBRAVER_BURST_NETWORK_MODE
     : "STANDALONE";
   switch (networkMode) {

--- a/src/js/sw.ts
+++ b/src/js/sw.ts
@@ -66,6 +66,18 @@ Routing.registerRoute(
 );
 
 Routing.registerRoute(
+  /(\/|config\.json)$/,
+  new Strategies.NetworkFirst({
+    cacheName: "config-json-cache",
+    plugins: [
+      new ExpirationPlugin({
+        maxAgeSeconds: 3 * 24 * 60 * 60,
+      }),
+    ],
+  }),
+);
+
+Routing.registerRoute(
   /\/resources\/.*\.(?:png|glb|mp3|svg|webp)$/,
   new Strategies.CacheFirst({
     cacheName: "resource-cache",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -118,6 +118,10 @@ module.exports = async () => ({
           from: path.resolve(__dirname, "src/pegass85.webp"),
           to: path.resolve(__dirname, BUILD_ROOT),
         },
+        {
+          from: path.resolve(__dirname, "src/config.json"),
+          to: path.resolve(__dirname, BUILD_ROOT),
+        },
       ],
     }),
     new webpack.DefinePlugin({


### PR DESCRIPTION
This pull request introduces a new `config.json` configuration file to control network feature availability at runtime, allowing the app's network mode to be dynamically set without redeployment. The codebase is updated to load and validate this configuration, and to ensure that the network mode is forced to `STANDALONE` when network features are disabled.

Configuration management and runtime behavior:

* Added a new `config.json` file with a `canNetWorkFeatures` boolean flag to control whether network features are enabled.
* Implemented a TypeScript module `config-json.ts` to fetch and validate `config.json` using a Zod schema, and defined the `ConfigJSON` type.
* Updated `main.ts` to import and use `fetchConfigJSON`, passing the configuration to `createNetworkContext` and using the `canNetWorkFeatures` flag to determine the effective network mode. [[1]](diffhunk://#diff-402ee6c1ed1f2975d1b05a54409139f2bdf76499515e61eb22b161c5053a2e3aR5) [[2]](diffhunk://#diff-402ee6c1ed1f2975d1b05a54409139f2bdf76499515e61eb22b161c5053a2e3aR49-R58) [[3]](diffhunk://#diff-402ee6c1ed1f2975d1b05a54409139f2bdf76499515e61eb22b161c5053a2e3aL75-R83)

Build and deployment:

* Modified `webpack.config.js` to ensure `config.json` is copied to the build output directory, so it is available at runtime.

Documentation:

* Updated `.env.template` to clarify that when `can-network-features` is set to false in `config.json`, the network mode is forcibly set to `STANDALONE`.