### PR TITLE
config.json上書きのCDプロジェクトを追加

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -318,6 +318,11 @@ shfmt -l -w *.bash
       "Effect": "Allow",
       "Action": ["s3:PutObject"],
       "Resource": "arn:aws:s3:::*/*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": "ssm:GetParameters",
+      "Resource": "*"
     }
   ]
 }

--- a/Readme.md
+++ b/Readme.md
@@ -74,11 +74,11 @@ npm start
 2. 「[Parameter Store（テスト環境）](#parameter-storeテスト環境)」を参考にParameter Storeに値を設定する
 3. 以下のCode Build（ソースコードは本リポジトリに設定したもの）を構築する
 
-| 役割              | buildspec                 | 環境                                                                                                         | IAMポリシー                                                      | webhook                                                 |
-| ----------------- | ------------------------- | ------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------- | ------------------------------------------------------- |
-| ビルド            | buildspec.yml             | [aws/codebuild/standard:7.0](https://github.com/aws/codebuild-docker-images/tree/master/ubuntu/standard/7.0) | [ビルド用IAMポリシー](#ビルド用iamポリシー)                      | [テスト環境ビルド用Webhook](#テスト環境ビルド用webhook) |
-| ステージ切り替え  | buildspec.switchStage.yml | [aws/codebuild/standard:7.0](https://github.com/aws/codebuild-docker-images/tree/master/ubuntu/standard/7.0) | [ステージ切り替え用IAMポリシー](#ステージ切り替え用iamポリシー)  | 設定なし                                                |
-| config.json上書き | buildspec.configJson.yml  | [aws/codebuild/standard:7.0](https://github.com/aws/codebuild-docker-images/tree/master/ubuntu/standard/7.0) | [config.json上書き用IAMポリシー](#configjson上書き用iamポリシー) | 設定なし                                                |
+| 役割              | buildspec                 | 環境                                                                                                             | IAMポリシー                                                      | webhook                                                 |
+| ----------------- | ------------------------- | ---------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- | ------------------------------------------------------- |
+| ビルド            | buildspec.yml             | [aws/codebuild/standard:7.0](https://github.com/aws/aws-codebuild-docker-images/tree/master/ubuntu/standard/7.0) | [ビルド用IAMポリシー](#ビルド用iamポリシー)                      | [テスト環境ビルド用Webhook](#テスト環境ビルド用webhook) |
+| ステージ切り替え  | buildspec.switchStage.yml | [aws/codebuild/standard:7.0](https://github.com/aws/aws-codebuild-docker-images/tree/master/ubuntu/standard/7.0) | [ステージ切り替え用IAMポリシー](#ステージ切り替え用iamポリシー)  | 設定なし                                                |
+| config.json上書き | buildspec.configJson.yml  | [aws/codebuild/standard:7.0](https://github.com/aws/aws-codebuild-docker-images/tree/master/ubuntu/standard/7.0) | [config.json上書き用IAMポリシー](#configjson上書き用iamポリシー) | 設定なし                                                |
 
 ### 本番環境
 

--- a/Readme.md
+++ b/Readme.md
@@ -40,7 +40,7 @@ npm start
 3. [aseetlinks.json](https://developers.google.com/digital-asset-links/v1/getting-started)を作成し、任意のS3バケットに配置する
 4. デプロイ対象のS3バケットを用意する
 
-### デプロイコマンド
+### 各種コマンド
 
 ```shell script
 # デプロイ
@@ -53,6 +53,13 @@ npm start
 # CDNのキャッシュをクリア
 # デプロイ、ステージ切り替えなどの一連の操作が終わったら実行する
 ./clear-cdn.bash <CloudFrontのdistributionId>
+
+# S3にあるconfig.jsonを上書きする
+# 本スクリプトの実行には、以下の環境変数が必要
+# - S3_BUCKET
+# - STAGE
+# - IS_BACKEND_SERVER_AVAILABLE
+./overwrite-config-json.bash
 ```
 
 ## AWSでCI/CDを構築する

--- a/Readme.md
+++ b/Readme.md
@@ -58,7 +58,7 @@ npm start
 # 本スクリプトの実行には、以下の環境変数が必要
 # - S3_BUCKET
 # - STAGE
-# - IS_BACKEND_SERVER_AVAILABLE
+# - IS_BACKEND_SERVER_AVAILABLE（省略可能、デフォルトはtrue）
 ./overwrite-config-json.bash
 ```
 

--- a/Readme.md
+++ b/Readme.md
@@ -74,10 +74,11 @@ npm start
 2. 「[Parameter Store（テスト環境）](#parameter-storeテスト環境)」を参考にParameter Storeに値を設定する
 3. 以下のCode Build（ソースコードは本リポジトリに設定したもの）を構築する
 
-| 役割             | buildspec                 | 環境                                                                                                             | IAMポリシー                                                     | webhook                                                 |
-| ---------------- | ------------------------- | ---------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- | ------------------------------------------------------- |
-| ビルド           | buildspec.yml             | [aws/codebuild/standard:7.0](https://github.com/aws/aws-codebuild-docker-images/tree/master/ubuntu/standard/7.0) | [ビルド用IAMポリシー](#ビルド用iamポリシー)                     | [テスト環境ビルド用Webhook](#テスト環境ビルド用webhook) |
-| ステージ切り替え | buildspec.switchStage.yml | [aws/codebuild/standard:7.0](https://github.com/aws/aws-codebuild-docker-images/tree/master/ubuntu/standard/7.0) | [ステージ切り替え用IAMポリシー](#ステージ切り替え用iamポリシー) | 設定なし                                                |
+| 役割              | buildspec                 | 環境                                                                                                         | IAMポリシー                                                      | webhook                                                 |
+| ----------------- | ------------------------- | ------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------- | ------------------------------------------------------- |
+| ビルド            | buildspec.yml             | [aws/codebuild/standard:7.0](https://github.com/aws/codebuild-docker-images/tree/master/ubuntu/standard/7.0) | [ビルド用IAMポリシー](#ビルド用iamポリシー)                      | [テスト環境ビルド用Webhook](#テスト環境ビルド用webhook) |
+| ステージ切り替え  | buildspec.switchStage.yml | [aws/codebuild/standard:7.0](https://github.com/aws/codebuild-docker-images/tree/master/ubuntu/standard/7.0) | [ステージ切り替え用IAMポリシー](#ステージ切り替え用iamポリシー)  | 設定なし                                                |
+| config.json上書き | buildspec.configJson.yml  | [aws/codebuild/standard:7.0](https://github.com/aws/codebuild-docker-images/tree/master/ubuntu/standard/7.0) | [config.json上書き用IAMポリシー](#configjson上書き用iamポリシー) | 設定なし                                                |
 
 ### 本番環境
 
@@ -85,10 +86,11 @@ npm start
 2. 「[Parameter Store（本番環境）](#parameter-store本番環境)」を参考にParameter Storeに値を設定する
 3. 以下のCode Build（ソースコードは本リポジトリに設定したもの）を構築する
 
-| 役割             | buildspec                      | 環境                                                                                                             | IAMポリシー                                                     | webhook                                             |
-| ---------------- | ------------------------------ | ---------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- | --------------------------------------------------- |
-| ビルド           | buildspec.prod.yml             | [aws/codebuild/standard:7.0](https://github.com/aws/aws-codebuild-docker-images/tree/master/ubuntu/standard/7.0) | [ビルド用IAMポリシー](#ビルド用iamポリシー)                     | [本番環境ビルド用Webhook](#本番環境ビルド用webhook) |
-| ステージ切り替え | buildspec.prod.switchStage.yml | [aws/codebuild/standard:7.0](https://github.com/aws/aws-codebuild-docker-images/tree/master/ubuntu/standard/7.0) | [ステージ切り替え用IAMポリシー](#ステージ切り替え用iamポリシー) | 設定なし                                            |
+| 役割              | buildspec                      | 環境                                                                                                             | IAMポリシー                                                      | webhook                                             |
+| ----------------- | ------------------------------ | ---------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- | --------------------------------------------------- |
+| ビルド            | buildspec.prod.yml             | [aws/codebuild/standard:7.0](https://github.com/aws/aws-codebuild-docker-images/tree/master/ubuntu/standard/7.0) | [ビルド用IAMポリシー](#ビルド用iamポリシー)                      | [本番環境ビルド用Webhook](#本番環境ビルド用webhook) |
+| ステージ切り替え  | buildspec.prod.switchStage.yml | [aws/codebuild/standard:7.0](https://github.com/aws/aws-codebuild-docker-images/tree/master/ubuntu/standard/7.0) | [ステージ切り替え用IAMポリシー](#ステージ切り替え用iamポリシー)  | 設定なし                                            |
+| config.json上書き | buildspec.configJson.prod.yml  | [aws/codebuild/standard:7.0](https://github.com/aws/aws-codebuild-docker-images/tree/master/ubuntu/standard/7.0) | [config.json上書き用IAMポリシー](#configjson上書き用iamポリシー) | 設定なし                                            |
 
 ## オフライン用LAN環境で動かす
 
@@ -301,6 +303,21 @@ shfmt -l -w *.bash
         "cloudfront:UpdateDistribution"
       ],
       "Resource": "*"
+    }
+  ]
+}
+```
+
+#### config.json上書き用IAMポリシー
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["s3:PutObject"],
+      "Resource": "arn:aws:s3:::*/*"
     }
   ]
 }

--- a/buildspec.configJson.prod.yml
+++ b/buildspec.configJson.prod.yml
@@ -1,9 +1,6 @@
 version: 0.2
 env:
-  variables:
-    IS_SEARCH_ENGINE_NO_INDEX: true
   parameter-store:
-    SERVICE: /GbraverBurst/prod/service
     STAGE: /GbraverBurst/prod/stage
     S3_BUCKET: /GbraverBurst/prod/s3Bucket
 phases:

--- a/buildspec.configJson.prod.yml
+++ b/buildspec.configJson.prod.yml
@@ -5,6 +5,7 @@ env:
   parameter-store:
     SERVICE: /GbraverBurst/prod/service
     STAGE: /GbraverBurst/prod/stage
+    S3_BUCKET: /GbraverBurst/prod/s3Bucket
 phases:
   build:
     commands:

--- a/buildspec.configJson.prod.yml
+++ b/buildspec.configJson.prod.yml
@@ -1,0 +1,11 @@
+version: 0.2
+env:
+  variables:
+    IS_SEARCH_ENGINE_NO_INDEX: true
+  parameter-store:
+    SERVICE: /GbraverBurst/prod/service
+    STAGE: /GbraverBurst/prod/stage
+phases:
+  build:
+    commands:
+      - ./overwrite-config-json.bash

--- a/buildspec.configJson.yml
+++ b/buildspec.configJson.yml
@@ -1,9 +1,6 @@
 version: 0.2
 env:
-  variables:
-    IS_SEARCH_ENGINE_NO_INDEX: true
   parameter-store:
-    SERVICE: /GbraverBurst/dev/service
     STAGE: /GbraverBurst/dev/stage
     S3_BUCKET: /GbraverBurst/dev/s3Bucket
 phases:

--- a/buildspec.configJson.yml
+++ b/buildspec.configJson.yml
@@ -1,0 +1,11 @@
+version: 0.2
+env:
+  variables:
+    IS_SEARCH_ENGINE_NO_INDEX: true
+  parameter-store:
+    SERVICE: /GbraverBurst/dev/service
+    STAGE: /GbraverBurst/dev/stage
+phases:
+  build:
+    commands:
+      - ./overwrite-config-json.bash

--- a/buildspec.configJson.yml
+++ b/buildspec.configJson.yml
@@ -5,6 +5,7 @@ env:
   parameter-store:
     SERVICE: /GbraverBurst/dev/service
     STAGE: /GbraverBurst/dev/stage
+    S3_BUCKET: /GbraverBurst/dev/s3Bucket
 phases:
   build:
     commands:

--- a/overwrite-config-json.bash
+++ b/overwrite-config-json.bash
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 set -Ceu
-touch config.json
-cat <<EOT > config.json
+cat <<EOT >| config.json
 {
   "isBackendServerAvailable": ${IS_BACKEND_SERVER_AVAILABLE:-true}
 }

--- a/overwrite-config-json.bash
+++ b/overwrite-config-json.bash
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+set -Ceu
 touch config.json
 cat <<EOT > config.json
 {

--- a/update-config-json.bash
+++ b/update-config-json.bash
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+touch config.json
+cat <<EOT > config.json
+{
+  "isBackendServerAvailable": ${IS_BACKEND_SERVER_AVAILABLE:-true}
+}
+EOT
+aws s3 cp --cache-control no-store config.json "s3://${S3_BUCKET:?}/${STAGE:?}/config.json"
+rm config.json


### PR DESCRIPTION
This pull request adds support for overwriting the `config.json` file in S3 as part of the deployment process, including new scripts, buildspecs, and documentation updates. The changes introduce a dedicated IAM policy, new CodeBuild jobs for both development and production, and instructions for usage.

**New config.json overwrite process:**

- Added a new script `overwrite-config-json.bash` to generate and upload `config.json` to the appropriate S3 bucket using environment variables.
- Introduced new CodeBuild buildspec files for config.json overwriting in both development (`buildspec.configJson.yml`) and production (`buildspec.configJson.prod.yml`) environments. [[1]](diffhunk://#diff-991b6c9a778f4a44bee0f74c45f6845c34ea2859c67286836299d8b63f272f2bR1-R12) [[2]](diffhunk://#diff-73525948a14486cfdf42dad587c11593e61833637f7cc8e5107820eeb5ecaa53R1-R12)
- Updated the documentation in `Readme.md` to:
  - Describe the new script and its required environment variables.
  - Add new CodeBuild job roles for config.json overwriting in both dev and prod tables. [[1]](diffhunk://#diff-1550ec65ac92f65817fc28928dfef526912b5f52356ff43651369bae92f56031L71-R81) [[2]](diffhunk://#diff-1550ec65ac92f65817fc28928dfef526912b5f52356ff43651369bae92f56031L82-R93)
  - Include a new IAM policy section specifically for config.json overwriting, detailing the required permissions.
  - Clarify command sections and improve formatting for easier understanding.