### PR TITLE
カスタムバトルイベントに画像プリロードを追加

### DIFF
--- a/src/js/custom-battle-events/battery-system-tutorial/index.ts
+++ b/src/js/custom-battle-events/battery-system-tutorial/index.ts
@@ -1,5 +1,7 @@
 import { Animate } from "../../animation/animate";
 import { Resources } from "../../resource";
+import { PathIds } from "../../resource/path/ids";
+import { PathId } from "../../resource/path/resource";
 import {
   BatteryCommandSelectedEventProps,
   BurstSelectedEventProps,
@@ -27,6 +29,14 @@ import {
 class BatterySystemTutorialEvent extends EmptyCustomBattleEvent {
   /** イベントプロパティ */
   #eventProps: BatterySystemTutorialProps;
+
+  /** @override */
+  readonly preloadImagePathIds: PathId[] = [
+    PathIds.MESSAGE_WINDOW_PLUS_BATTERY,
+    PathIds.MESSAGE_WINDOW_MINUS_BATTERY,
+    PathIds.MESSAGE_WINDOW_ATTACK_BATTERY,
+    PathIds.MESSAGE_WINDOW_DEFENSE_BATTERY,
+  ];
 
   /**
    * コンストラクタ

--- a/src/js/custom-battle-events/empty-custom-battle-event.ts
+++ b/src/js/custom-battle-events/empty-custom-battle-event.ts
@@ -1,5 +1,6 @@
 import { Animate } from "../animation/animate";
 import { empty } from "../animation/delay";
+import { PathId } from "../resource/path/resource";
 import type {
   BatteryCommandSelectedEventProps,
   BattleSimulatorEventProps,
@@ -17,6 +18,9 @@ import type {
  * CustomBattleEventのデフォルト実装を定義する目的で、本クラスを利用すること
  */
 export class EmptyCustomBattleEvent implements CustomBattleEvent {
+  /** @override */
+  readonly preloadImagePathIds: PathId[] = [];
+
   /** @override */
   /* eslint-disable @typescript-eslint/no-unused-vars */
   onStateUpdateStarted(props: StateUpdateStartedEventProps): void {

--- a/src/js/game/game-procedure/start-episode.ts
+++ b/src/js/game/game-procedure/start-episode.ts
@@ -55,16 +55,15 @@ export async function startEpisode(options: {
   const config = await props.config.load();
   props.renderer.setPixelRatio(config.webGLPixelRatio);
   const players: [Player, Player] = [npcBattle.player, npcBattle.enemy];
+  props.resources = await updateBattleSceneResources({
+    resources: props.resources,
+    players,
+  });
   const customBattleEvent = episode.event(props.resources);
-  const [updatedResources] = await Promise.all([
-    updateBattleSceneResources({
-      resources: props.resources,
-      players,
-    }),
+  await Promise.all([
     preloadBattleSceneImages(props.resources, players),
     preloadImages(props.resources, customBattleEvent.preloadImagePathIds),
   ]);
-  props.resources = updatedResources;
   const battleScene = new BattleScene({
     ...props,
     isRetry,

--- a/src/js/game/game-procedure/start-episode.ts
+++ b/src/js/game/game-procedure/start-episode.ts
@@ -4,7 +4,10 @@ import { fadeOut, stop } from "../../bgm/bgm-operators";
 import { MAX_LOADING_TIME } from "../../dom-scenes/dom-scene-binder/max-loading-time";
 import { EpisodeTitle } from "../../dom-scenes/episode-title";
 import { NPCBattleRoom } from "../../npc/npc-battle-room";
-import { preloadBattleSceneImages } from "../../resource/preload-images";
+import {
+  preloadBattleSceneImages,
+  preloadImages,
+} from "../../resource/preload-images";
 import { updateBattleSceneResources } from "../../resource/update-battle-scene-resources";
 import { BattleScene } from "../../td-scenes/battle";
 import { waitAnimationFrame } from "../../wait/wait-animation-frame";
@@ -52,12 +55,14 @@ export async function startEpisode(options: {
   const config = await props.config.load();
   props.renderer.setPixelRatio(config.webGLPixelRatio);
   const players: [Player, Player] = [npcBattle.player, npcBattle.enemy];
+  const customBattleEvent = episode.event(props.resources);
   const [updatedResources] = await Promise.all([
     updateBattleSceneResources({
       resources: props.resources,
       players,
     }),
     preloadBattleSceneImages(props.resources, players),
+    preloadImages(props.resources, customBattleEvent.preloadImagePathIds),
   ]);
   props.resources = updatedResources;
   const battleScene = new BattleScene({
@@ -69,7 +74,7 @@ export async function startEpisode(options: {
     player: npcBattle.player,
     enemy: npcBattle.enemy,
     initialState: npcBattle.stateHistory(),
-    customBattleEvent: episode.event(props.resources),
+    customBattleEvent,
     controllerType: "BigButton",
     playerPilotVisibility: "visible",
     canRetry: true,

--- a/src/js/game/game-procedure/start-local-battle.ts
+++ b/src/js/game/game-procedure/start-local-battle.ts
@@ -7,7 +7,10 @@ import { NetworkErrorDialog } from "../../dom-dialogs/network-error/network-erro
 import { WaitingDialog } from "../../dom-dialogs/waiting/waiting-dialog";
 import { MAX_LOADING_TIME } from "../../dom-scenes/dom-scene-binder/max-loading-time";
 import { MatchCard } from "../../dom-scenes/match-card";
-import { preloadBattleSceneImages } from "../../resource/preload-images";
+import {
+  preloadBattleSceneImages,
+  preloadImages,
+} from "../../resource/preload-images";
 import { SOUND_IDS } from "../../resource/sound/ids";
 import { updateBattleSceneResources } from "../../resource/update-battle-scene-resources";
 import { BattleScene } from "../../td-scenes/battle";
@@ -79,12 +82,14 @@ export const startLocalBattle = async (props: GameProps, battle: BattleSDK) => {
   const config = await props.config.load();
   props.renderer.setPixelRatio(config.webGLPixelRatio);
   const players: [Player, Player] = [battle.player, battle.enemy];
+  const customBattleEvent = createSeriousMatchEvent();
   const [updatedResources] = await Promise.all([
     updateBattleSceneResources({
       resources: props.resources,
       players,
     }),
     preloadBattleSceneImages(props.resources, players),
+    preloadImages(props.resources, customBattleEvent.preloadImagePathIds),
   ]);
   props.resources = updatedResources;
   const battleScene = new BattleScene({
@@ -98,7 +103,7 @@ export const startLocalBattle = async (props: GameProps, battle: BattleSDK) => {
     controllerType: config.battleControllerType,
     playerPilotVisibility: config.playerPilotVisibility,
     emergencyStop: battle.suddenlyBattleEndNotifier(),
-    customBattleEvent: createSeriousMatchEvent(),
+    customBattleEvent,
     canRetry: false,
   });
   bindBattleScene(props, battleScene);

--- a/src/js/game/game-procedure/start-local-battle.ts
+++ b/src/js/game/game-procedure/start-local-battle.ts
@@ -82,16 +82,15 @@ export const startLocalBattle = async (props: GameProps, battle: BattleSDK) => {
   const config = await props.config.load();
   props.renderer.setPixelRatio(config.webGLPixelRatio);
   const players: [Player, Player] = [battle.player, battle.enemy];
+  props.resources = await updateBattleSceneResources({
+    resources: props.resources,
+    players,
+  });
   const customBattleEvent = createSeriousMatchEvent();
-  const [updatedResources] = await Promise.all([
-    updateBattleSceneResources({
-      resources: props.resources,
-      players,
-    }),
+  await Promise.all([
     preloadBattleSceneImages(props.resources, players),
     preloadImages(props.resources, customBattleEvent.preloadImagePathIds),
   ]);
-  props.resources = updatedResources;
   const battleScene = new BattleScene({
     ...props,
     playingBGM: SOUND_IDS.BATTLE_BGM_01,

--- a/src/js/game/game-procedure/start-npc-battle-stage.ts
+++ b/src/js/game/game-procedure/start-npc-battle-stage.ts
@@ -5,7 +5,10 @@ import { createSeriousMatchEvent } from "../../custom-battle-events/serious-matc
 import { MAX_LOADING_TIME } from "../../dom-scenes/dom-scene-binder/max-loading-time";
 import { StageTitle } from "../../dom-scenes/stage-title";
 import { NPCBattleRoom } from "../../npc/npc-battle-room";
-import { preloadBattleSceneImages } from "../../resource/preload-images";
+import {
+  preloadBattleSceneImages,
+  preloadImages,
+} from "../../resource/preload-images";
 import { updateBattleSceneResources } from "../../resource/update-battle-scene-resources";
 import { BattleScene } from "../../td-scenes/battle";
 import { waitAnimationFrame } from "../../wait/wait-animation-frame";
@@ -55,12 +58,14 @@ export async function startNPCBattleStage(
   const config = await props.config.load();
   props.renderer.setPixelRatio(config.webGLPixelRatio);
   const players: [Player, Player] = [npcBattle.player, npcBattle.enemy];
+  const customBattleEvent = createSeriousMatchEvent();
   const [updatedResources] = await Promise.all([
     updateBattleSceneResources({
       resources: props.resources,
       players,
     }),
     preloadBattleSceneImages(props.resources, players),
+    preloadImages(props.resources, customBattleEvent.preloadImagePathIds),
   ]);
   props.resources = updatedResources;
   const battleScene = new BattleScene({
@@ -73,7 +78,7 @@ export async function startNPCBattleStage(
     initialState: npcBattle.stateHistory(),
     controllerType: config.battleControllerType,
     playerPilotVisibility: config.playerPilotVisibility,
-    customBattleEvent: createSeriousMatchEvent(),
+    customBattleEvent,
     canRetry: true,
   });
   bindBattleScene(props, battleScene);

--- a/src/js/game/game-procedure/start-npc-battle-stage.ts
+++ b/src/js/game/game-procedure/start-npc-battle-stage.ts
@@ -58,16 +58,15 @@ export async function startNPCBattleStage(
   const config = await props.config.load();
   props.renderer.setPixelRatio(config.webGLPixelRatio);
   const players: [Player, Player] = [npcBattle.player, npcBattle.enemy];
+  props.resources = await updateBattleSceneResources({
+    resources: props.resources,
+    players,
+  });
   const customBattleEvent = createSeriousMatchEvent();
-  const [updatedResources] = await Promise.all([
-    updateBattleSceneResources({
-      resources: props.resources,
-      players,
-    }),
+  await Promise.all([
     preloadBattleSceneImages(props.resources, players),
     preloadImages(props.resources, customBattleEvent.preloadImagePathIds),
   ]);
-  props.resources = updatedResources;
   const battleScene = new BattleScene({
     ...props,
     playingBGM: stage.bgm,

--- a/src/js/game/game-procedure/start-online-battle.ts
+++ b/src/js/game/game-procedure/start-online-battle.ts
@@ -88,16 +88,15 @@ export async function startOnlineBattle(
   const config = await props.config.load();
   props.renderer.setPixelRatio(config.webGLPixelRatio);
   const players: [Player, Player] = [battle.player, battle.enemy];
+  props.resources = await updateBattleSceneResources({
+    resources: props.resources,
+    players,
+  });
   const customBattleEvent = createSeriousMatchEvent();
-  const [updatedResources] = await Promise.all([
-    updateBattleSceneResources({
-      resources: props.resources,
-      players,
-    }),
+  await Promise.all([
     preloadBattleSceneImages(props.resources, players),
     preloadImages(props.resources, customBattleEvent.preloadImagePathIds),
   ]);
-  props.resources = updatedResources;
   const battleScene = new BattleScene({
     ...props,
     playingBGM: SOUND_IDS.BATTLE_BGM_01,

--- a/src/js/game/game-procedure/start-online-battle.ts
+++ b/src/js/game/game-procedure/start-online-battle.ts
@@ -7,7 +7,10 @@ import { NetworkErrorDialog } from "../../dom-dialogs/network-error/network-erro
 import { WaitingDialog } from "../../dom-dialogs/waiting/waiting-dialog";
 import { MAX_LOADING_TIME } from "../../dom-scenes/dom-scene-binder/max-loading-time";
 import { MatchCard } from "../../dom-scenes/match-card";
-import { preloadBattleSceneImages } from "../../resource/preload-images";
+import {
+  preloadBattleSceneImages,
+  preloadImages,
+} from "../../resource/preload-images";
 import { SOUND_IDS } from "../../resource/sound/ids";
 import { updateBattleSceneResources } from "../../resource/update-battle-scene-resources";
 import { BattleScene } from "../../td-scenes/battle";
@@ -85,12 +88,14 @@ export async function startOnlineBattle(
   const config = await props.config.load();
   props.renderer.setPixelRatio(config.webGLPixelRatio);
   const players: [Player, Player] = [battle.player, battle.enemy];
+  const customBattleEvent = createSeriousMatchEvent();
   const [updatedResources] = await Promise.all([
     updateBattleSceneResources({
       resources: props.resources,
       players,
     }),
     preloadBattleSceneImages(props.resources, players),
+    preloadImages(props.resources, customBattleEvent.preloadImagePathIds),
   ]);
   props.resources = updatedResources;
   const battleScene = new BattleScene({
@@ -104,7 +109,7 @@ export async function startOnlineBattle(
     controllerType: config.battleControllerType,
     playerPilotVisibility: config.playerPilotVisibility,
     emergencyStop: battle.suddenlyBattleEndNotifier(),
-    customBattleEvent: createSeriousMatchEvent(),
+    customBattleEvent,
     canRetry: false,
   });
   bindBattleScene(props, battleScene);

--- a/src/js/td-scenes/battle/custom-battle-event.ts
+++ b/src/js/td-scenes/battle/custom-battle-event.ts
@@ -15,6 +15,7 @@ import { PushWindow } from "../../window/push-window";
 import { AnimationTimeScaleContainer } from "./animation-time-scale-container";
 import { BattleSceneSounds } from "./sounds";
 import { BattleSceneView } from "./view";
+import { PathId } from "../../resource/path/resource";
 
 /**
  * 全カスタムイベントで利用できるプロパティ
@@ -158,6 +159,9 @@ export type BattleSimulatorEventProps = CustomBattleEventProps &
 
 /** カスタムバトルイベント */
 export interface CustomBattleEvent {
+  /** プリロードする画像のパスIDを指定する */
+  readonly preloadImagePathIds: PathId[];
+
   /**
    * ステート更新が開始された時に呼ばれるイベント
    * @param props イベントプロパティ

--- a/src/js/td-scenes/battle/custom-battle-event.ts
+++ b/src/js/td-scenes/battle/custom-battle-event.ts
@@ -10,12 +10,12 @@ import { Observable } from "rxjs";
 
 import { AbortManagerContainer } from "../../abort-controller/abort-manager-container";
 import { Animate } from "../../animation/animate";
+import { PathId } from "../../resource/path/resource";
 import { SEPlayerContainer } from "../../se/se-player";
 import { PushWindow } from "../../window/push-window";
 import { AnimationTimeScaleContainer } from "./animation-time-scale-container";
 import { BattleSceneSounds } from "./sounds";
 import { BattleSceneView } from "./view";
-import { PathId } from "../../resource/path/resource";
 
 /**
  * 全カスタムイベントで利用できるプロパティ


### PR DESCRIPTION
This pull request introduces a new mechanism for preloading custom images required by custom battle events, ensuring that all necessary assets are loaded before a battle begins. The main changes involve adding a `preloadImagePathIds` property to the `CustomBattleEvent` interface and updating the battle initialization procedures to preload these images. This improves reliability and performance by preventing missing asset issues during custom events.

**Custom Battle Event Image Preloading**

* Added a new `preloadImagePathIds` property to the `CustomBattleEvent` interface, allowing each event to specify which image assets should be preloaded before the battle starts.
* Implemented the `preloadImagePathIds` property in `EmptyCustomBattleEvent` (returns an empty array) and in `BatterySystemTutorialEvent` (returns a list of required image path IDs). [[1]](diffhunk://#diff-c3eb5f0c0ddc92910e3c9bdd11b17421f1e769f020a178eead1dc1a758d134e6R21-R23) [[2]](diffhunk://#diff-9db5f178386d4adf3fa9ee2dbee89dcc9dbb6d86af8b2ea3797213023a7d169aR33-R40)

**Battle Initialization Updates**

* Updated all battle start procedures (`startEpisode`, `startLocalBattle`, `startNPCBattleStage`, `startOnlineBattle`) to collect the `preloadImagePathIds` from the relevant custom battle event and call `preloadImages` to ensure these assets are loaded before the scene begins. [[1]](diffhunk://#diff-558c139a76c53f3bdf2cd726faf9266e03ca0783c18325c6e3c23a008f42a822R58-R65) [[2]](diffhunk://#diff-396d3efac3fb963dc7a94bf28da6194b9655e503c8a01fb308c2687a3e603c73R85-R92) [[3]](diffhunk://#diff-5c5d64d99d4737a6a3c180677f366690a59921ff4f8e04ab7d06874d14bc9557R61-R68) [[4]](diffhunk://#diff-58e9738d98443309fab927a5d785d8072050252b09a5fed57ba268c5bba92d21R91-R98)
* Refactored imports to include the new `preloadImages` function where needed. [[1]](diffhunk://#diff-558c139a76c53f3bdf2cd726faf9266e03ca0783c18325c6e3c23a008f42a822L7-R10) [[2]](diffhunk://#diff-396d3efac3fb963dc7a94bf28da6194b9655e503c8a01fb308c2687a3e603c73L10-R13) [[3]](diffhunk://#diff-5c5d64d99d4737a6a3c180677f366690a59921ff4f8e04ab7d06874d14bc9557L8-R11) [[4]](diffhunk://#diff-58e9738d98443309fab927a5d785d8072050252b09a5fed57ba268c5bba92d21L10-R13)

**Code Consistency and Refactoring**

* Updated the instantiation and passing of `customBattleEvent` in battle scene constructors to ensure the same instance is used for preloading and for the battle logic. [[1]](diffhunk://#diff-558c139a76c53f3bdf2cd726faf9266e03ca0783c18325c6e3c23a008f42a822L72-R77) [[2]](diffhunk://#diff-396d3efac3fb963dc7a94bf28da6194b9655e503c8a01fb308c2687a3e603c73L101-R106) [[3]](diffhunk://#diff-5c5d64d99d4737a6a3c180677f366690a59921ff4f8e04ab7d06874d14bc9557L76-R81) [[4]](diffhunk://#diff-58e9738d98443309fab927a5d785d8072050252b09a5fed57ba268c5bba92d21L107-R112)
* Added necessary imports for `PathId` and related resources in affected files. [[1]](diffhunk://#diff-9db5f178386d4adf3fa9ee2dbee89dcc9dbb6d86af8b2ea3797213023a7d169aR3-R4) [[2]](diffhunk://#diff-c3eb5f0c0ddc92910e3c9bdd11b17421f1e769f020a178eead1dc1a758d134e6R3) [[3]](diffhunk://#diff-ea917122253348e36f1b7227574d2a2e274394d5f22a44ff432d79f9b3e35d53R13)

These changes make the image preloading process for custom battle events explicit and reliable, reducing the risk of missing assets during event execution.