### PR TITLE
ネット対戦系のタイトルマッチを日本語にした

### DIFF
--- a/src/js/game/game-procedure/on-game-action/on-private-match-entry.ts
+++ b/src/js/game/game-procedure/on-game-action/on-private-match-entry.ts
@@ -51,5 +51,5 @@ export async function onPrivateMatchEntry(options: Options): Promise<void> {
     ...props.inProgress,
     privateMatchGuest: { type: "Battle" },
   };
-  await startOnlineBattle(props, battle, "PRIVATE MATCH");
+  await startOnlineBattle(props, battle, "プライベートマッチ");
 }

--- a/src/js/game/game-procedure/on-game-action/on-selection-complete/start-casual-match-if-needed.ts
+++ b/src/js/game/game-procedure/on-game-action/on-selection-complete/start-casual-match-if-needed.ts
@@ -42,7 +42,7 @@ export async function startCasualMatchIfNeeded(
     { ...props, networkContext },
     action,
   );
-  await startOnlineBattle(props, battle, "CASUAL MATCH");
+  await startOnlineBattle(props, battle, "カジュアルマッチ");
   return {
     isStarted: true,
     inProgress: {

--- a/src/js/game/game-procedure/on-game-action/on-selection-complete/start-offline-lan-casual-match.ts
+++ b/src/js/game/game-procedure/on-game-action/on-selection-complete/start-offline-lan-casual-match.ts
@@ -23,7 +23,7 @@ export async function startOfflineLANCasualMatch(
 ): Promise<InProgress> {
   props.networkContext.sdk.closeConnection();
   const battle = await waitUntilOfflineLANCasualMatching(props, action);
-  await startOnlineBattle(props, battle, "CASUAL MATCH");
+  await startOnlineBattle(props, battle, "カジュアルマッチ");
   return {
     ...props.inProgress,
     offlineLANCasualMatch: { type: "Battle" },

--- a/src/js/game/game-procedure/on-game-action/on-selection-complete/start-private-match-host-if-needed.ts
+++ b/src/js/game/game-procedure/on-game-action/on-selection-complete/start-private-match-host-if-needed.ts
@@ -43,7 +43,7 @@ export async function startPrivateMatchHostIfNeeded(
     { ...props, networkContext },
     action,
   );
-  await startOnlineBattle(props, battle, "PRIVATE MATCH");
+  await startOnlineBattle(props, battle, "プライベートマッチ");
   return {
     isStarted: true,
     inProgress: {

--- a/src/js/game/game-procedure/start-local-battle.ts
+++ b/src/js/game/game-procedure/start-local-battle.ts
@@ -73,7 +73,7 @@ export const startLocalBattle = async (props: GameProps, battle: BattleSDK) => {
     resources: props.resources,
     player: battle.player.armdozer.id,
     enemy: battle.enemy.armdozer.id,
-    caption: "Local Battle",
+    caption: "あいことば対戦",
   });
   switchMatchCard(props, scene);
   await Promise.race([scene.waitUntilLoaded(), waitTime(MAX_LOADING_TIME)]);


### PR DESCRIPTION
This pull request updates the captions used for different match types throughout the codebase to use Japanese language strings instead of English. This change ensures consistency and localization for the user interface.

**Localization updates for match captions:**

* Changed the caption for private matches from `"PRIVATE MATCH"` to `"プライベートマッチ"` in both guest and host entry points (`on-private-match-entry.ts`, `start-private-match-host-if-needed.ts`). [[1]](diffhunk://#diff-b97541089aff95e0e4f49ed73439632af226ff80ca830cfe65935881b3391c2dL54-R54) [[2]](diffhunk://#diff-809ceb9796dff5c718fad53021555277efd13750d108064cf9af8493dd395fbbL46-R46)
* Changed the caption for casual matches from `"CASUAL MATCH"` to `"カジュアルマッチ"` in both online and offline LAN match flows (`start-casual-match-if-needed.ts`, `start-offline-lan-casual-match.ts`). [[1]](diffhunk://#diff-40904e9e054a1e8b3766061e9fb3b6819ddb3d247ad8ee16d334722ba1297e12L45-R45) [[2]](diffhunk://#diff-b06e1f3e13b5105b34e4833c079f770c5797b7c30e0dd9fff5ecf8eb23956e05L26-R26)
* Changed the caption for local battles from `"Local Battle"` to `"あいことば対戦"` in `start-local-battle.ts`.