### PR TITLE
あいことば対戦用SDKをアップグレードした

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "1.0.0",
       "license": "CC-BY-4.0",
       "dependencies": {
-        "@gbraver-burst-network/browser-sdk": "1.25.2",
-        "@gbraver-burst-network/local-webrtc-browser-sdk": "1.25.2",
-        "@gbraver-burst-network/offline-browser-sdk": "1.25.2",
+        "@gbraver-burst-network/browser-sdk": "1.26.0",
+        "@gbraver-burst-network/local-webrtc-browser-sdk": "1.26.0",
+        "@gbraver-burst-network/offline-browser-sdk": "1.26.0",
         "@tweenjs/tween.js": "^25.0.0",
         "gbraver-burst-core": "1.45.0",
         "handlebars": "^4.7.9",
@@ -3963,37 +3963,37 @@
       }
     },
     "node_modules/@gbraver-burst-network/browser-sdk": {
-      "version": "1.25.2",
-      "resolved": "https://registry.npmjs.org/@gbraver-burst-network/browser-sdk/-/browser-sdk-1.25.2.tgz",
-      "integrity": "sha512-vQZ7Aisn4MWOOt5XznMLDZ4R8/EwxIYj0Z2Fc0cSFykBjCSMsaRftUKYPR5UFiDw+iQkEUi7L1pPWOupZ92Y7A==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@gbraver-burst-network/browser-sdk/-/browser-sdk-1.26.0.tgz",
+      "integrity": "sha512-eY9TIGL9tCcRcho4u+NuPVcIMlDG0aMJMsW6s5DataOU2QnQQEBF+F4HFK4d/IKPEsX8z6xf4HAU7HEdhkIf4A==",
       "license": "MIT",
       "dependencies": {
         "aws-amplify": "^6.18.0",
         "rxjs": "^7.8.2"
       },
       "peerDependencies": {
-        "gbraver-burst-core": "^1.44.0",
+        "gbraver-burst-core": "^1.45.0",
         "zod": "^4.4.3"
       }
     },
     "node_modules/@gbraver-burst-network/local-webrtc-browser-sdk": {
-      "version": "1.25.2",
-      "resolved": "https://registry.npmjs.org/@gbraver-burst-network/local-webrtc-browser-sdk/-/local-webrtc-browser-sdk-1.25.2.tgz",
-      "integrity": "sha512-tolMsRNIv6l5zmuxc/wQPUVIJGG5XcabgnbWlTU6zME16A9/1NY8LzdmetIwlDQWDdGsiH87VjnVueTOSZnSOA==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@gbraver-burst-network/local-webrtc-browser-sdk/-/local-webrtc-browser-sdk-1.26.0.tgz",
+      "integrity": "sha512-/9jL4x5LJ/H0Lst2Ocfr5L0YAzkcV3Z1CE8SrpsQZ4TVXtI2LlDG/tdAaHtc+b8AMm2BF9Ug8K4xp1dihOX9gg==",
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^5.1.11",
+        "nanoid": "^5.1.16",
         "rxjs": "^7.8.2"
       },
       "peerDependencies": {
-        "gbraver-burst-core": "^1.44.0",
+        "gbraver-burst-core": "^1.45.0",
         "zod": "^4.4.3"
       }
     },
     "node_modules/@gbraver-burst-network/local-webrtc-browser-sdk/node_modules/nanoid": {
-      "version": "5.1.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.11.tgz",
-      "integrity": "sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg==",
+      "version": "5.1.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.16.tgz",
+      "integrity": "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==",
       "funding": [
         {
           "type": "github",
@@ -4009,16 +4009,16 @@
       }
     },
     "node_modules/@gbraver-burst-network/offline-browser-sdk": {
-      "version": "1.25.2",
-      "resolved": "https://registry.npmjs.org/@gbraver-burst-network/offline-browser-sdk/-/offline-browser-sdk-1.25.2.tgz",
-      "integrity": "sha512-mXbWOEnGydWI+37LCxYnc9Z56raHejJEQ0hmcK39Azz+vx0swZAs6cIJBuQSZHejU/dm/WKd95R9ff++UJrnjA==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@gbraver-burst-network/offline-browser-sdk/-/offline-browser-sdk-1.26.0.tgz",
+      "integrity": "sha512-mCqw5KOaFTubpYkNiByp1HBlAuBF+WG4l9oWwTcsYHA5ljsc3Ra55z4O2a44nMnMDZR4kxA2/nydqm6vuhJ4qQ==",
       "license": "MIT",
       "dependencies": {
         "rxjs": "^7.8.2",
         "socket.io-client": "^4.8.3"
       },
       "peerDependencies": {
-        "gbraver-burst-core": "^1.44.0",
+        "gbraver-burst-core": "^1.45.0",
         "zod": "^4.4.3"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "1.0.0",
       "license": "CC-BY-4.0",
       "dependencies": {
-        "@gbraver-burst-network/browser-sdk": "1.26.0",
-        "@gbraver-burst-network/local-webrtc-browser-sdk": "1.26.0",
-        "@gbraver-burst-network/offline-browser-sdk": "1.26.0",
+        "@gbraver-burst-network/browser-sdk": "1.26.1-beta.0",
+        "@gbraver-burst-network/local-webrtc-browser-sdk": "1.26.1-beta.0",
+        "@gbraver-burst-network/offline-browser-sdk": "1.26.1-beta.0",
         "@tweenjs/tween.js": "^25.0.0",
         "gbraver-burst-core": "1.45.0",
         "handlebars": "^4.7.9",
@@ -3963,9 +3963,9 @@
       }
     },
     "node_modules/@gbraver-burst-network/browser-sdk": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/@gbraver-burst-network/browser-sdk/-/browser-sdk-1.26.0.tgz",
-      "integrity": "sha512-eY9TIGL9tCcRcho4u+NuPVcIMlDG0aMJMsW6s5DataOU2QnQQEBF+F4HFK4d/IKPEsX8z6xf4HAU7HEdhkIf4A==",
+      "version": "1.26.1-beta.0",
+      "resolved": "https://registry.npmjs.org/@gbraver-burst-network/browser-sdk/-/browser-sdk-1.26.1-beta.0.tgz",
+      "integrity": "sha512-iMXBZg1MAtVOL4KhlcdQUHu1o95i4BwWICL5g8YffPOSX/uXn8u9Fsc2dZ+gI62fZvxKMOoFxyPIqMFtRqKu0Q==",
       "license": "MIT",
       "dependencies": {
         "aws-amplify": "^6.18.0",
@@ -3977,9 +3977,9 @@
       }
     },
     "node_modules/@gbraver-burst-network/local-webrtc-browser-sdk": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/@gbraver-burst-network/local-webrtc-browser-sdk/-/local-webrtc-browser-sdk-1.26.0.tgz",
-      "integrity": "sha512-/9jL4x5LJ/H0Lst2Ocfr5L0YAzkcV3Z1CE8SrpsQZ4TVXtI2LlDG/tdAaHtc+b8AMm2BF9Ug8K4xp1dihOX9gg==",
+      "version": "1.26.1-beta.0",
+      "resolved": "https://registry.npmjs.org/@gbraver-burst-network/local-webrtc-browser-sdk/-/local-webrtc-browser-sdk-1.26.1-beta.0.tgz",
+      "integrity": "sha512-wPty9VeyJ7CdaW7Qz7q8wz668btu5pD5HkaHfdITsPjA/0sMLGdpgL9xsUGolBt0U4O9MwuxbfPQBk82nBZQow==",
       "license": "MIT",
       "dependencies": {
         "nanoid": "^5.1.16",
@@ -4009,9 +4009,9 @@
       }
     },
     "node_modules/@gbraver-burst-network/offline-browser-sdk": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/@gbraver-burst-network/offline-browser-sdk/-/offline-browser-sdk-1.26.0.tgz",
-      "integrity": "sha512-mCqw5KOaFTubpYkNiByp1HBlAuBF+WG4l9oWwTcsYHA5ljsc3Ra55z4O2a44nMnMDZR4kxA2/nydqm6vuhJ4qQ==",
+      "version": "1.26.1-beta.0",
+      "resolved": "https://registry.npmjs.org/@gbraver-burst-network/offline-browser-sdk/-/offline-browser-sdk-1.26.1-beta.0.tgz",
+      "integrity": "sha512-gE6q9UoZa/6nqAiMlcYXPBkYjOuNFxYWDPA38T67tDDDSY7CQelhV6+37YYJAjKeeqohzcLTYSboOtpsTClCAA==",
       "license": "MIT",
       "dependencies": {
         "rxjs": "^7.8.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "1.0.0",
       "license": "CC-BY-4.0",
       "dependencies": {
-        "@gbraver-burst-network/browser-sdk": "1.26.1-beta.0",
-        "@gbraver-burst-network/local-webrtc-browser-sdk": "1.26.1-beta.0",
-        "@gbraver-burst-network/offline-browser-sdk": "1.26.1-beta.0",
+        "@gbraver-burst-network/browser-sdk": "1.26.1",
+        "@gbraver-burst-network/local-webrtc-browser-sdk": "1.26.1",
+        "@gbraver-burst-network/offline-browser-sdk": "1.26.1",
         "@tweenjs/tween.js": "^25.0.0",
         "gbraver-burst-core": "1.45.0",
         "handlebars": "^4.7.9",
@@ -3963,9 +3963,9 @@
       }
     },
     "node_modules/@gbraver-burst-network/browser-sdk": {
-      "version": "1.26.1-beta.0",
-      "resolved": "https://registry.npmjs.org/@gbraver-burst-network/browser-sdk/-/browser-sdk-1.26.1-beta.0.tgz",
-      "integrity": "sha512-iMXBZg1MAtVOL4KhlcdQUHu1o95i4BwWICL5g8YffPOSX/uXn8u9Fsc2dZ+gI62fZvxKMOoFxyPIqMFtRqKu0Q==",
+      "version": "1.26.1",
+      "resolved": "https://registry.npmjs.org/@gbraver-burst-network/browser-sdk/-/browser-sdk-1.26.1.tgz",
+      "integrity": "sha512-0uWtwOX55aVndbnvYPUSaJgxnY2g514HRXWYzq0yArb0nkjZNpSMXB/YkuP40T3t0LMfJhOHWEZA5IdCbQ5/9A==",
       "license": "MIT",
       "dependencies": {
         "aws-amplify": "^6.18.0",
@@ -3977,9 +3977,9 @@
       }
     },
     "node_modules/@gbraver-burst-network/local-webrtc-browser-sdk": {
-      "version": "1.26.1-beta.0",
-      "resolved": "https://registry.npmjs.org/@gbraver-burst-network/local-webrtc-browser-sdk/-/local-webrtc-browser-sdk-1.26.1-beta.0.tgz",
-      "integrity": "sha512-wPty9VeyJ7CdaW7Qz7q8wz668btu5pD5HkaHfdITsPjA/0sMLGdpgL9xsUGolBt0U4O9MwuxbfPQBk82nBZQow==",
+      "version": "1.26.1",
+      "resolved": "https://registry.npmjs.org/@gbraver-burst-network/local-webrtc-browser-sdk/-/local-webrtc-browser-sdk-1.26.1.tgz",
+      "integrity": "sha512-u3YaqCPnL5kiyeTmwHcU+O2A/hPHFMu/bYAPRVRwbPUnhFu0r0USavNN0jqXYpjx6aI1x1TvAK0Edw8/VrTKbQ==",
       "license": "MIT",
       "dependencies": {
         "nanoid": "^5.1.16",
@@ -4009,9 +4009,9 @@
       }
     },
     "node_modules/@gbraver-burst-network/offline-browser-sdk": {
-      "version": "1.26.1-beta.0",
-      "resolved": "https://registry.npmjs.org/@gbraver-burst-network/offline-browser-sdk/-/offline-browser-sdk-1.26.1-beta.0.tgz",
-      "integrity": "sha512-gE6q9UoZa/6nqAiMlcYXPBkYjOuNFxYWDPA38T67tDDDSY7CQelhV6+37YYJAjKeeqohzcLTYSboOtpsTClCAA==",
+      "version": "1.26.1",
+      "resolved": "https://registry.npmjs.org/@gbraver-burst-network/offline-browser-sdk/-/offline-browser-sdk-1.26.1.tgz",
+      "integrity": "sha512-yrTsEZoakcA5JHfumB5VyfxssbNUpNqFElrUhSdvrN55CK1t/rJ6K5NpUSU9XNxNBKv+6VXXKLClExsPO9FJSw==",
       "license": "MIT",
       "dependencies": {
         "rxjs": "^7.8.2",
@@ -23434,9 +23434,9 @@
       }
     },
     "node_modules/webpack-dev-server": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.5.tgz",
-      "integrity": "sha512-4wZtCquSuv9CKX8oybo+mqxtxZqWz47uM1Ch94lxowBztOhWCbhqvRbfC/mODOwxgV2brY+JGZpHq58/SuVFYg==",
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.6.tgz",
+      "integrity": "sha512-HNLRmamRvVavZQ+avceZifmv8hmdUjg43t6MI4SqJDwFdW7RPQwH5vzGhDRZSX59SgfbeHhLnq3g+uooWo7pVw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -23458,7 +23458,7 @@
         "graceful-fs": "^4.2.6",
         "http-proxy-middleware": "^2.0.9",
         "ipaddr.js": "^2.1.0",
-        "launch-editor": "^2.6.1",
+        "launch-editor": "^2.14.1",
         "open": "^10.0.3",
         "p-retry": "^6.2.0",
         "schema-utils": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
     "email": "kaidouji85@gmail.com"
   },
   "dependencies": {
-    "@gbraver-burst-network/browser-sdk": "1.26.1-beta.0",
-    "@gbraver-burst-network/local-webrtc-browser-sdk": "1.26.1-beta.0",
-    "@gbraver-burst-network/offline-browser-sdk": "1.26.1-beta.0",
+    "@gbraver-burst-network/browser-sdk": "1.26.1",
+    "@gbraver-burst-network/local-webrtc-browser-sdk": "1.26.1",
+    "@gbraver-burst-network/offline-browser-sdk": "1.26.1",
     "@tweenjs/tween.js": "^25.0.0",
     "gbraver-burst-core": "1.45.0",
     "handlebars": "^4.7.9",

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
     "email": "kaidouji85@gmail.com"
   },
   "dependencies": {
-    "@gbraver-burst-network/browser-sdk": "1.25.2",
-    "@gbraver-burst-network/local-webrtc-browser-sdk": "1.25.2",
-    "@gbraver-burst-network/offline-browser-sdk": "1.25.2",
+    "@gbraver-burst-network/browser-sdk": "1.26.0",
+    "@gbraver-burst-network/local-webrtc-browser-sdk": "1.26.0",
+    "@gbraver-burst-network/offline-browser-sdk": "1.26.0",
     "@tweenjs/tween.js": "^25.0.0",
     "gbraver-burst-core": "1.45.0",
     "handlebars": "^4.7.9",

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
     "email": "kaidouji85@gmail.com"
   },
   "dependencies": {
-    "@gbraver-burst-network/browser-sdk": "1.26.0",
-    "@gbraver-burst-network/local-webrtc-browser-sdk": "1.26.0",
-    "@gbraver-burst-network/offline-browser-sdk": "1.26.0",
+    "@gbraver-burst-network/browser-sdk": "1.26.1-beta.0",
+    "@gbraver-burst-network/local-webrtc-browser-sdk": "1.26.1-beta.0",
+    "@gbraver-burst-network/offline-browser-sdk": "1.26.1-beta.0",
     "@tweenjs/tween.js": "^25.0.0",
     "gbraver-burst-core": "1.45.0",
     "handlebars": "^4.7.9",

--- a/src/js/game/game-procedure/on-game-action/on-force-end-battle/force-end-net-battle.ts
+++ b/src/js/game/game-procedure/on-game-action/on-force-end-battle/force-end-net-battle.ts
@@ -33,6 +33,7 @@ export async function forceEndNetBattle(
 ) {
   const dialog = new WaitingDialog("通信中......");
   switchWaitingDialog(props, dialog);
+  props.suddenlyBattleEnd.unbind();
   await disconnectConnection(props);
   props.domDialogBinder.hidden();
   const [title] = await Promise.all([

--- a/src/js/game/game-props/generate-game-props.ts
+++ b/src/js/game/game-props/generate-game-props.ts
@@ -15,10 +15,10 @@ import { TDSceneBinder } from "../../td-scenes/td-scene-binder";
 import { pushWindowsStream } from "../../window/push-window";
 import { resizeStream } from "../../window/resize";
 import { GBraverBurstBrowserConfigRepository } from "../config/repository/repository";
-import { FutureSuddenlyBattleEnd } from "../future-suddenly-battle-end";
 import { GameAction } from "../game-actions";
 import { InterruptScenes } from "../innterrupt-scenes";
 import { NetworkContext } from "../network-context";
+import { SuddenlyBattleEnd } from "../suddenly-battle-end";
 import { GameProps } from "./index";
 
 /** GamePropsジェネレータパラメータ */
@@ -85,7 +85,7 @@ export function generateGameProps(params: GamePropsGeneratorParams): GameProps {
     gameLoop,
     gameAction: createActionManager<GameAction>(),
     hudUIScale: new CssHUDUIScale(renderer.getRendererDOM(), resize),
-    suddenlyBattleEnd: new FutureSuddenlyBattleEnd(),
+    suddenlyBattleEnd: new SuddenlyBattleEnd(),
     fader: new DOMFader(),
     interruptScenes: new InterruptScenes(),
     domSceneBinder: new DOMSceneBinder(),

--- a/src/js/game/game-props/index.ts
+++ b/src/js/game/game-props/index.ts
@@ -17,11 +17,11 @@ import { TDSceneBinder } from "../../td-scenes/td-scene-binder";
 import { PushWindow } from "../../window/push-window";
 import { Resize } from "../../window/resize";
 import { GBraverBurstBrowserConfigRepository } from "../config/repository/repository";
-import { FutureSuddenlyBattleEnd } from "../future-suddenly-battle-end";
 import { InProgress } from "../in-progress";
 import { InterruptScenes } from "../innterrupt-scenes";
 import { NetworkContext } from "../network-context";
 import { SharedResourceState } from "../shared-resource-state";
+import { SuddenlyBattleEnd } from "../suddenly-battle-end";
 import { GameActionManageContainer } from "./game-action-manage-container";
 
 /**
@@ -73,7 +73,7 @@ export interface GameProps
   /** ネットワークコンテキスト */
   readonly networkContext: NetworkContext;
   /** バトル強制終了監視 */
-  readonly suddenlyBattleEnd: FutureSuddenlyBattleEnd;
+  readonly suddenlyBattleEnd: SuddenlyBattleEnd;
 
   /** リサイズ */
   readonly resize: Observable<Resize>;

--- a/src/js/game/suddenly-battle-end.ts
+++ b/src/js/game/suddenly-battle-end.ts
@@ -1,8 +1,8 @@
 import { BattleSDK } from "@gbraver-burst-network/browser-sdk";
 import { Observable, Subject, Unsubscribable } from "rxjs";
 
-/** 将来生成されるバトル管理オブジェクトからバトル強制終了ストリームを取り出す */
-export class FutureSuddenlyBattleEnd {
+/** バトル管理オブジェクトからバトル強制終了ストリームを取り出す */
+export class SuddenlyBattleEnd {
   #notifier: Subject<void>;
   #unsubscriber: Unsubscribable | null;
 


### PR DESCRIPTION
This pull request updates the battle forced-end monitoring feature and upgrades several SDK dependencies. The main change is a refactor: the `FutureSuddenlyBattleEnd` class has been renamed and replaced by `SuddenlyBattleEnd` throughout the codebase, simplifying its usage. Additionally, the `@gbraver-burst-network` SDK dependencies have been updated to a newer version.

Dependency upgrades:

* Updated `@gbraver-burst-network/browser-sdk`, `@gbraver-burst-network/local-webrtc-browser-sdk`, and `@gbraver-burst-network/offline-browser-sdk` from version `1.25.2` to `1.26.1` in `package.json`.

Battle forced-end monitoring refactor:

* Renamed `src/js/game/future-suddenly-battle-end.ts` to `src/js/game/suddenly-battle-end.ts` and changed the class name from `FutureSuddenlyBattleEnd` to `SuddenlyBattleEnd`.
* Updated all imports and type references from `FutureSuddenlyBattleEnd` to `SuddenlyBattleEnd` in `src/js/game/game-props/index.ts` and `src/js/game/game-props/generate-game-props.ts`. [[1]](diffhunk://#diff-ce24a62c74cd2851c79f37d55fdd9e3fe006e513c2569b9e57ce49a3d1f85a8eL20-R24) [[2]](diffhunk://#diff-ce24a62c74cd2851c79f37d55fdd9e3fe006e513c2569b9e57ce49a3d1f85a8eL76-R76) [[3]](diffhunk://#diff-dc2f6df13b711e47b9da0588aee33aaf2ceebbe35ad3714cad0b80d1078864c2L18-R21) [[4]](diffhunk://#diff-dc2f6df13b711e47b9da0588aee33aaf2ceebbe35ad3714cad0b80d1078864c2L88-R88)
* Ensured that `suddenlyBattleEnd.unbind()` is called before disconnecting the network connection in `forceEndNetBattle`, improving cleanup logic.