### PR TITLE
フェーダーを色々修正した

### DIFF
--- a/src/js/game-object/fader/animation/fade-in.ts
+++ b/src/js/game-object/fader/animation/fade-in.ts
@@ -1,25 +1,12 @@
 import { Animate } from "../../../animation/animate";
-import { onStart } from "../../../animation/on-start";
 import { tween } from "../../../animation/tween";
 import type { FaderModel } from "../model/fader-model";
 
 /**
  * フェードイン
- *
  * @param model モデル
  * @returns アニメーション
  */
 export function fadeIn(model: FaderModel): Animate {
-  return onStart(() => {
-    model.opacity = 1;
-  }).chain(
-    tween(model, (t) =>
-      t.to(
-        {
-          opacity: 0,
-        },
-        500,
-      ),
-    ),
-  );
+  return tween(model, (t) => t.to({ opacity: 0 }, 500));
 }

--- a/src/js/game-object/fader/animation/fade-in.ts
+++ b/src/js/game-object/fader/animation/fade-in.ts
@@ -5,8 +5,9 @@ import type { FaderModel } from "../model/fader-model";
 /**
  * フェードイン
  * @param model モデル
+ * @param duration アニメーションの時間（ミリ秒）
  * @returns アニメーション
  */
-export function fadeIn(model: FaderModel): Animate {
-  return tween(model, (t) => t.to({ opacity: 0 }, 500));
+export function fadeIn(model: FaderModel, duration: number): Animate {
+  return tween(model, (t) => t.to({ opacity: 0 }, duration));
 }

--- a/src/js/game-object/fader/animation/fade-out.ts
+++ b/src/js/game-object/fader/animation/fade-out.ts
@@ -1,25 +1,12 @@
 import { Animate } from "../../../animation/animate";
-import { onStart } from "../../../animation/on-start";
 import { tween } from "../../../animation/tween";
 import type { FaderModel } from "../model/fader-model";
 
 /**
  * フェードアウト
- *
  * @param model モデル
  * @returns アニメーション
  */
 export function fadeOut(model: FaderModel): Animate {
-  return onStart(() => {
-    model.opacity = 0;
-  }).chain(
-    tween(model, (t) =>
-      t.to(
-        {
-          opacity: 1,
-        },
-        500,
-      ),
-    ),
-  );
+  return tween(model, (t) => t.to({ opacity: 1 }, 500));
 }

--- a/src/js/game-object/fader/animation/fade-out.ts
+++ b/src/js/game-object/fader/animation/fade-out.ts
@@ -5,8 +5,9 @@ import type { FaderModel } from "../model/fader-model";
 /**
  * フェードアウト
  * @param model モデル
+ * @param duration アニメーションの時間（ミリ秒）
  * @returns アニメーション
  */
-export function fadeOut(model: FaderModel): Animate {
-  return tween(model, (t) => t.to({ opacity: 1 }, 500));
+export function fadeOut(model: FaderModel, duration: number): Animate {
+  return tween(model, (t) => t.to({ opacity: 1 }, duration));
 }

--- a/src/js/game-object/fader/fader.ts
+++ b/src/js/game-object/fader/fader.ts
@@ -54,18 +54,20 @@ export class Fader {
 
   /**
    * フェードイン
+   * @param duration アニメーションの時間（ミリ秒）、省略時は500
    * @returns アニメーション
    */
-  fadeIn(): Animate {
-    return fadeIn(this.#model);
+  fadeIn(duration: number = 500): Animate {
+    return fadeIn(this.#model, duration);
   }
 
   /**
    * フェードアウト
+   * @param duration アニメーションの時間（ミリ秒）、省略時は500
    * @returns アニメーション
    */
-  fadeOut(): Animate {
-    return fadeOut(this.#model);
+  fadeOut(duration: number = 500): Animate {
+    return fadeOut(this.#model, duration);
   }
 
   /**

--- a/src/js/game-object/fader/model/fader-model.ts
+++ b/src/js/game-object/fader/model/fader-model.ts
@@ -2,10 +2,8 @@
 export type FaderModel = {
   /** 0から1で指定する不透明度、0で完全透明 */
   opacity: number;
-
   /** 画面幅 */
   width: number;
-
   /** 画面高 */
   height: number;
 };

--- a/src/js/game-object/fader/view/death-alert-view.ts
+++ b/src/js/game-object/fader/view/death-alert-view.ts
@@ -34,7 +34,7 @@ export class DeathAlertView implements FaderView {
     const material = new THREE.MeshBasicMaterial({
       color: "rgb(255, 0, 0)",
       transparent: true,
-      map: texture.texture,
+      alphaMap: texture.texture,
     });
     this.#mesh = new THREE.Mesh(geometry, material);
     this.#mesh.position.z = z;

--- a/stories/fader.stories.ts
+++ b/stories/fader.stories.ts
@@ -10,9 +10,9 @@ export default {
 export const deathAlert = hudGameObjectStory((params) => {
   const vignette = deathAlertVignette({ ...params, isVisible: false });
   delay(1000)
-    .chain(vignette.fadeIn())
-    .chain(delay(1000))
     .chain(vignette.fadeOut())
+    .chain(delay(1000))
+    .chain(vignette.fadeIn())
     .chain(delay(1000))
     .loop();
   return [vignette.getObject3D()];


### PR DESCRIPTION
This pull request improves the flexibility and clarity of the fader animation system by allowing custom animation durations for fade-in and fade-out effects, simplifying the animation logic, and fixing a material property in the death alert view. The most important changes are grouped below:

### Animation Duration and API Improvements

* Updated the `fadeIn` and `fadeOut` functions in `fade-in.ts` and `fade-out.ts` to accept a `duration` parameter, allowing callers to specify animation length instead of using a hardcoded value. The animation logic was also simplified by removing the `onStart` step. [[1]](diffhunk://#diff-7a034d69d9bb05c86cc8a1c5836b7a572d2f112d55c49cf2be59cb898523e99aL2-R12) [[2]](diffhunk://#diff-e6995ac8221c5d78f7906f309fc0f3335d6bec244c3cb0bd6053d22f5a61c2d6L2-R12)
* Modified the `Fader` class in `fader.ts` so that `fadeIn` and `fadeOut` methods accept an optional `duration` parameter (defaulting to 500ms), passing this value to the animation functions.

### Bug Fixes and Refactoring

* Fixed the `DeathAlertView` in `death-alert-view.ts` to use the `alphaMap` property instead of `map` for the material, ensuring correct transparency handling.
* Cleaned up the `FaderModel` type definition by removing unnecessary blank lines.

### Story and Demo Logic

* Reordered the animation calls in `fader.stories.ts` so that the fade-out occurs before the fade-in, improving the logic flow of the vignette animation demo.