### PR TITLE
ダウン演出を調整

### DIFF
--- a/src/js/td-scenes/battle/animation/game-state/battle/attack/genesis-braver/down.ts
+++ b/src/js/td-scenes/battle/animation/game-state/battle/attack/genesis-braver/down.ts
@@ -27,15 +27,15 @@ export function down(param: GenesisBraverBattle<DownResult>): Animate {
       all(
         param.tdObjects.skyBrightness.brightness(0.3, 100),
         param.tdObjects.illumination.intensity(0.3, 100),
-        delay(2100).chain(param.attackerSprite.spToStand()).chain(delay(500)),
+        delay(1900).chain(param.attackerSprite.spToStand()).chain(delay(500)),
         toInitial(param.tdCamera, 100),
         param.defenderTD.damageIndicator.popUp(param.result.damage),
         onStart(() => param.bgm.do(stop)),
-        all(param.defenderSprite.knockBack(), delay(800)).chain(
+        all(param.defenderSprite.knockBack(), delay(600)).chain(
           all(
             param.defenderSprite.down(),
-            param.tdObjects.skyBrightness.brightness(1, 500),
-            param.tdObjects.illumination.intensity(1, 500),
+            param.tdObjects.skyBrightness.brightness(1, 100),
+            param.tdObjects.illumination.intensity(1, 100),
             delay(param.defenderSprite.downImpactDelay).chain(
               all(
                 onStart(() => param.se.play(param.bigExplosion)),

--- a/src/js/td-scenes/battle/animation/game-state/battle/attack/gran-dozer/down.ts
+++ b/src/js/td-scenes/battle/animation/game-state/battle/attack/gran-dozer/down.ts
@@ -27,17 +27,17 @@ export function down(param: GranDozerBattle<DownResult>): Animate {
       all(
         param.tdObjects.skyBrightness.brightness(0.3, 100),
         param.tdObjects.illumination.intensity(0.3, 100),
-        delay(2100)
+        delay(1900)
           .chain(param.attackerSprite.tackleToStand())
           .chain(delay(500)),
         toInitial(param.tdCamera, 100),
         param.defenderTD.damageIndicator.popUp(param.result.damage),
         onStart(() => param.bgm.do(stop)),
-        all(param.defenderSprite.knockBack(), delay(800)).chain(
+        all(param.defenderSprite.knockBack(), delay(600)).chain(
           all(
             param.defenderSprite.down(),
-            param.tdObjects.skyBrightness.brightness(1, 500),
-            param.tdObjects.illumination.intensity(1, 500),
+            param.tdObjects.skyBrightness.brightness(1, 100),
+            param.tdObjects.illumination.intensity(1, 100),
             delay(param.defenderSprite.downImpactDelay).chain(
               all(
                 onStart(() => param.se.play(param.bigExplosion)),

--- a/src/js/td-scenes/battle/animation/game-state/battle/attack/lightning-dozer/down.ts
+++ b/src/js/td-scenes/battle/animation/game-state/battle/attack/lightning-dozer/down.ts
@@ -27,15 +27,15 @@ export function down(param: LightningDozerBattle<DownResult>): Animate {
       all(
         param.tdObjects.skyBrightness.brightness(0.3, 100),
         param.tdObjects.illumination.intensity(0.3, 100),
-        delay(2100).chain(param.attackerSprite.hmToStand()).chain(delay(500)),
+        delay(1900).chain(param.attackerSprite.hmToStand()).chain(delay(500)),
         toInitial(param.tdCamera, 100),
         param.defenderTD.damageIndicator.popUp(param.result.damage),
         onStart(() => param.bgm.do(stop)),
-        all(param.defenderSprite.knockBack(), delay(800)).chain(
+        all(param.defenderSprite.knockBack(), delay(600)).chain(
           all(
             param.defenderSprite.down(),
-            param.tdObjects.skyBrightness.brightness(1, 500),
-            param.tdObjects.illumination.intensity(1, 500),
+            param.tdObjects.skyBrightness.brightness(1, 100),
+            param.tdObjects.illumination.intensity(1, 100),
             delay(param.defenderSprite.downImpactDelay).chain(
               all(
                 onStart(() => param.se.play(param.bigExplosion)),

--- a/src/js/td-scenes/battle/animation/game-state/battle/attack/neo-landozer/down.ts
+++ b/src/js/td-scenes/battle/animation/game-state/battle/attack/neo-landozer/down.ts
@@ -27,7 +27,7 @@ export function down(param: NeoLandozerBattle<DownResult>): Animate {
       all(
         param.tdObjects.skyBrightness.brightness(0.3, 100),
         param.tdObjects.illumination.intensity(0.3, 100),
-        delay(1900).chain(param.attackerSprite.hmToStand()).chain(delay(500)),
+        delay(1800).chain(param.attackerSprite.hmToStand()).chain(delay(600)),
         toInitial(param.tdCamera, 100),
         param.defenderTD.damageIndicator.popUp(param.result.damage),
         onStart(() => param.bgm.do(stop)),

--- a/src/js/td-scenes/battle/animation/game-state/battle/attack/neo-landozer/down.ts
+++ b/src/js/td-scenes/battle/animation/game-state/battle/attack/neo-landozer/down.ts
@@ -27,15 +27,15 @@ export function down(param: NeoLandozerBattle<DownResult>): Animate {
       all(
         param.tdObjects.skyBrightness.brightness(0.3, 100),
         param.tdObjects.illumination.intensity(0.3, 100),
-        delay(2100).chain(param.attackerSprite.hmToStand()).chain(delay(500)),
+        delay(1900).chain(param.attackerSprite.hmToStand()).chain(delay(500)),
         toInitial(param.tdCamera, 100),
         param.defenderTD.damageIndicator.popUp(param.result.damage),
         onStart(() => param.bgm.do(stop)),
-        all(param.defenderSprite.knockBack(), delay(800)).chain(
+        all(param.defenderSprite.knockBack(), delay(600)).chain(
           all(
             param.defenderSprite.down(),
-            param.tdObjects.skyBrightness.brightness(1, 500),
-            param.tdObjects.illumination.intensity(1, 500),
+            param.tdObjects.skyBrightness.brightness(1, 100),
+            param.tdObjects.illumination.intensity(1, 100),
             delay(param.defenderSprite.downImpactDelay).chain(
               all(
                 onStart(() => param.se.play(param.bigExplosion)),

--- a/src/js/td-scenes/battle/animation/game-state/battle/attack/neo-landozer/down.ts
+++ b/src/js/td-scenes/battle/animation/game-state/battle/attack/neo-landozer/down.ts
@@ -27,7 +27,7 @@ export function down(param: NeoLandozerBattle<DownResult>): Animate {
       all(
         param.tdObjects.skyBrightness.brightness(0.3, 100),
         param.tdObjects.illumination.intensity(0.3, 100),
-        delay(1800).chain(param.attackerSprite.hmToStand()).chain(delay(600)),
+        delay(1900).chain(param.attackerSprite.hmToStand()).chain(delay(500)),
         toInitial(param.tdCamera, 100),
         param.defenderTD.damageIndicator.popUp(param.result.damage),
         onStart(() => param.bgm.do(stop)),

--- a/src/js/td-scenes/battle/animation/game-state/battle/attack/shin-braver/down.ts
+++ b/src/js/td-scenes/battle/animation/game-state/battle/attack/shin-braver/down.ts
@@ -27,9 +27,9 @@ export function down(param: ShinBraverBattle<DownResult>): Animate {
       all(
         param.tdObjects.skyBrightness.brightness(0.3, 100),
         param.tdObjects.illumination.intensity(0.3, 100),
-        delay(1900)
+        delay(1800)
           .chain(param.attackerSprite.punchToStand())
-          .chain(delay(500)),
+          .chain(delay(600)),
         toInitial(param.tdCamera, 100),
         param.defenderTD.damageIndicator.popUp(param.result.damage),
         onStart(() => param.bgm.do(stop)),

--- a/src/js/td-scenes/battle/animation/game-state/battle/attack/shin-braver/down.ts
+++ b/src/js/td-scenes/battle/animation/game-state/battle/attack/shin-braver/down.ts
@@ -27,9 +27,9 @@ export function down(param: ShinBraverBattle<DownResult>): Animate {
       all(
         param.tdObjects.skyBrightness.brightness(0.3, 100),
         param.tdObjects.illumination.intensity(0.3, 100),
-        delay(1800)
+        delay(1900)
           .chain(param.attackerSprite.punchToStand())
-          .chain(delay(600)),
+          .chain(delay(500)),
         toInitial(param.tdCamera, 100),
         param.defenderTD.damageIndicator.popUp(param.result.damage),
         onStart(() => param.bgm.do(stop)),

--- a/src/js/td-scenes/battle/animation/game-state/battle/attack/shin-braver/down.ts
+++ b/src/js/td-scenes/battle/animation/game-state/battle/attack/shin-braver/down.ts
@@ -27,17 +27,17 @@ export function down(param: ShinBraverBattle<DownResult>): Animate {
       all(
         param.tdObjects.skyBrightness.brightness(0.3, 100),
         param.tdObjects.illumination.intensity(0.3, 100),
-        delay(2100)
+        delay(1900)
           .chain(param.attackerSprite.punchToStand())
           .chain(delay(500)),
         toInitial(param.tdCamera, 100),
         param.defenderTD.damageIndicator.popUp(param.result.damage),
         onStart(() => param.bgm.do(stop)),
-        all(param.defenderSprite.knockBack(), delay(800)).chain(
+        all(param.defenderSprite.knockBack(), delay(600)).chain(
           all(
             param.defenderSprite.down(),
-            param.tdObjects.skyBrightness.brightness(1, 500),
-            param.tdObjects.illumination.intensity(1, 500),
+            param.tdObjects.skyBrightness.brightness(1, 100),
+            param.tdObjects.illumination.intensity(1, 100),
             delay(param.defenderSprite.downImpactDelay).chain(
               all(
                 onStart(() => param.se.play(param.bigExplosion)),

--- a/src/js/td-scenes/battle/animation/game-state/battle/attack/wing-dozer/down.ts
+++ b/src/js/td-scenes/battle/animation/game-state/battle/attack/wing-dozer/down.ts
@@ -27,17 +27,17 @@ export function down(param: WingDozerBattle<DownResult>): Animate {
       all(
         param.tdObjects.skyBrightness.brightness(0.3, 100),
         param.tdObjects.illumination.intensity(0.3, 100),
-        delay(2100)
+        delay(1900)
           .chain(param.attackerSprite.upperToStand())
           .chain(delay(500)),
         toInitial(param.tdCamera, 100),
         param.defenderTD.damageIndicator.popUp(param.result.damage),
         onStart(() => param.bgm.do(stop)),
-        all(param.defenderSprite.knockBack(), delay(800)).chain(
+        all(param.defenderSprite.knockBack(), delay(600)).chain(
           all(
             param.defenderSprite.down(),
-            param.tdObjects.skyBrightness.brightness(1, 500),
-            param.tdObjects.illumination.intensity(1, 500),
+            param.tdObjects.skyBrightness.brightness(1, 100),
+            param.tdObjects.illumination.intensity(1, 100),
             delay(param.defenderSprite.downImpactDelay).chain(
               all(
                 onStart(() => param.se.play(param.bigExplosion)),


### PR DESCRIPTION
This pull request adjusts the timing and duration of various animation sequences for the "down" action across multiple battle scenes. The main goal is to make the animations faster and more responsive by reducing delays and shortening brightness/illumination transitions.

**Animation timing improvements:**

* Reduced the initial delay before the attacker's transition to standing pose in all `down` animation functions (e.g., changed from 2100ms to 1800ms/1900ms depending on the file). [[1]](diffhunk://#diff-8ef930a1e9484f7dd3156eecbce9bf53a1ffe6fc017988fa5703da3387742795L30-R38) [[2]](diffhunk://#diff-e03485720e8f2e8d0498a94f6ceef8eb374ecb3ae2a3123aa74ad7fb4778f7f7L30-R40) [[3]](diffhunk://#diff-51c219ec6771103b5380e670df82547ee5bbf3ef7078c572f9c0f150517537e4L30-R38) [[4]](diffhunk://#diff-f49147a89fe3aac69a19f6641553efe83621783b38d99a09616526e82c3b3d72L30-R38) [[5]](diffhunk://#diff-33463fd59d8df0fa64134c36cbc6eb320d10c0f5c469bbaf11f33f3392053889L30-R40) [[6]](diffhunk://#diff-50e31a136ac27c995dfb5a2804deca055a685bd10e469d395cf3bf4e701c5aabL30-R40)
* Adjusted the delay after the attacker's pose transition, with some increases (e.g., 500ms to 600ms) for smoother sequencing. [[1]](diffhunk://#diff-f49147a89fe3aac69a19f6641553efe83621783b38d99a09616526e82c3b3d72L30-R38) [[2]](diffhunk://#diff-33463fd59d8df0fa64134c36cbc6eb320d10c0f5c469bbaf11f33f3392053889L30-R40)

**Defender and environment animation speedups:**

* Shortened the knockback delay for the defender from 800ms to 600ms, making the reaction quicker. [[1]](diffhunk://#diff-8ef930a1e9484f7dd3156eecbce9bf53a1ffe6fc017988fa5703da3387742795L30-R38) [[2]](diffhunk://#diff-e03485720e8f2e8d0498a94f6ceef8eb374ecb3ae2a3123aa74ad7fb4778f7f7L30-R40) [[3]](diffhunk://#diff-51c219ec6771103b5380e670df82547ee5bbf3ef7078c572f9c0f150517537e4L30-R38) [[4]](diffhunk://#diff-f49147a89fe3aac69a19f6641553efe83621783b38d99a09616526e82c3b3d72L30-R38) [[5]](diffhunk://#diff-33463fd59d8df0fa64134c36cbc6eb320d10c0f5c469bbaf11f33f3392053889L30-R40) [[6]](diffhunk://#diff-50e31a136ac27c995dfb5a2804deca055a685bd10e469d395cf3bf4e701c5aabL30-R40)
* Reduced the duration of sky brightness and illumination transitions after the defender is downed from 500ms to 100ms, resulting in faster visual feedback. [[1]](diffhunk://#diff-8ef930a1e9484f7dd3156eecbce9bf53a1ffe6fc017988fa5703da3387742795L30-R38) [[2]](diffhunk://#diff-e03485720e8f2e8d0498a94f6ceef8eb374ecb3ae2a3123aa74ad7fb4778f7f7L30-R40) [[3]](diffhunk://#diff-51c219ec6771103b5380e670df82547ee5bbf3ef7078c572f9c0f150517537e4L30-R38) [[4]](diffhunk://#diff-f49147a89fe3aac69a19f6641553efe83621783b38d99a09616526e82c3b3d72L30-R38) [[5]](diffhunk://#diff-33463fd59d8df0fa64134c36cbc6eb320d10c0f5c469bbaf11f33f3392053889L30-R40) [[6]](diffhunk://#diff-50e31a136ac27c995dfb5a2804deca055a685bd10e469d395cf3bf4e701c5aabL30-R40)

These changes collectively make the "down" animations more dynamic and reduce perceived sluggishness during battle sequences.