### PR TITLE
ダウン演出を調整

### DIFF
--- a/src/js/td-scenes/battle/animation/game-state/battle/attack/genesis-braver/down.ts
+++ b/src/js/td-scenes/battle/animation/game-state/battle/attack/genesis-braver/down.ts
@@ -27,15 +27,19 @@ export function down(param: GenesisBraverBattle<DownResult>): Animate {
       all(
         param.tdObjects.skyBrightness.brightness(0.3, 100),
         param.tdObjects.illumination.intensity(0.3, 100),
-        delay(1900).chain(param.attackerSprite.spToStand()).chain(delay(500)),
+        delay(1900).chain(
+          all(
+            param.attackerSprite.spToStand().chain(delay(500)),
+            param.tdObjects.skyBrightness.brightness(1, 500),
+            param.tdObjects.illumination.intensity(1, 500),
+          ),
+        ),
         toInitial(param.tdCamera, 100),
         param.defenderTD.damageIndicator.popUp(param.result.damage),
         onStart(() => param.bgm.do(stop)),
         all(param.defenderSprite.knockBack(), delay(600)).chain(
           all(
             param.defenderSprite.down(),
-            param.tdObjects.skyBrightness.brightness(1, 100),
-            param.tdObjects.illumination.intensity(1, 100),
             delay(param.defenderSprite.downImpactDelay).chain(
               all(
                 onStart(() => param.se.play(param.bigExplosion)),

--- a/src/js/td-scenes/battle/animation/game-state/battle/attack/gran-dozer/down.ts
+++ b/src/js/td-scenes/battle/animation/game-state/battle/attack/gran-dozer/down.ts
@@ -27,17 +27,19 @@ export function down(param: GranDozerBattle<DownResult>): Animate {
       all(
         param.tdObjects.skyBrightness.brightness(0.3, 100),
         param.tdObjects.illumination.intensity(0.3, 100),
-        delay(1900)
-          .chain(param.attackerSprite.tackleToStand())
-          .chain(delay(500)),
+        delay(1900).chain(
+          all(
+            param.attackerSprite.tackleToStand().chain(delay(500)),
+            param.tdObjects.skyBrightness.brightness(1, 500),
+            param.tdObjects.illumination.intensity(1, 500),
+          ),
+        ),
         toInitial(param.tdCamera, 100),
         param.defenderTD.damageIndicator.popUp(param.result.damage),
         onStart(() => param.bgm.do(stop)),
         all(param.defenderSprite.knockBack(), delay(600)).chain(
           all(
             param.defenderSprite.down(),
-            param.tdObjects.skyBrightness.brightness(1, 100),
-            param.tdObjects.illumination.intensity(1, 100),
             delay(param.defenderSprite.downImpactDelay).chain(
               all(
                 onStart(() => param.se.play(param.bigExplosion)),

--- a/src/js/td-scenes/battle/animation/game-state/battle/attack/lightning-dozer/down.ts
+++ b/src/js/td-scenes/battle/animation/game-state/battle/attack/lightning-dozer/down.ts
@@ -27,15 +27,19 @@ export function down(param: LightningDozerBattle<DownResult>): Animate {
       all(
         param.tdObjects.skyBrightness.brightness(0.3, 100),
         param.tdObjects.illumination.intensity(0.3, 100),
-        delay(1900).chain(param.attackerSprite.hmToStand()).chain(delay(500)),
+        delay(1900).chain(
+          all(
+            param.attackerSprite.hmToStand().chain(delay(500)),
+            param.tdObjects.skyBrightness.brightness(1, 500),
+            param.tdObjects.illumination.intensity(1, 500),
+          ),
+        ),
         toInitial(param.tdCamera, 100),
         param.defenderTD.damageIndicator.popUp(param.result.damage),
         onStart(() => param.bgm.do(stop)),
         all(param.defenderSprite.knockBack(), delay(600)).chain(
           all(
             param.defenderSprite.down(),
-            param.tdObjects.skyBrightness.brightness(1, 100),
-            param.tdObjects.illumination.intensity(1, 100),
             delay(param.defenderSprite.downImpactDelay).chain(
               all(
                 onStart(() => param.se.play(param.bigExplosion)),

--- a/src/js/td-scenes/battle/animation/game-state/battle/attack/neo-landozer/down.ts
+++ b/src/js/td-scenes/battle/animation/game-state/battle/attack/neo-landozer/down.ts
@@ -27,15 +27,19 @@ export function down(param: NeoLandozerBattle<DownResult>): Animate {
       all(
         param.tdObjects.skyBrightness.brightness(0.3, 100),
         param.tdObjects.illumination.intensity(0.3, 100),
-        delay(1900).chain(param.attackerSprite.hmToStand()).chain(delay(500)),
+        delay(1900).chain(
+          all(
+            param.attackerSprite.hmToStand().chain(delay(500)),
+            param.tdObjects.skyBrightness.brightness(1, 500),
+            param.tdObjects.illumination.intensity(1, 500),
+          ),
+        ),
         toInitial(param.tdCamera, 100),
         param.defenderTD.damageIndicator.popUp(param.result.damage),
         onStart(() => param.bgm.do(stop)),
         all(param.defenderSprite.knockBack(), delay(600)).chain(
           all(
             param.defenderSprite.down(),
-            param.tdObjects.skyBrightness.brightness(1, 100),
-            param.tdObjects.illumination.intensity(1, 100),
             delay(param.defenderSprite.downImpactDelay).chain(
               all(
                 onStart(() => param.se.play(param.bigExplosion)),

--- a/src/js/td-scenes/battle/animation/game-state/battle/attack/shin-braver/down.ts
+++ b/src/js/td-scenes/battle/animation/game-state/battle/attack/shin-braver/down.ts
@@ -27,17 +27,19 @@ export function down(param: ShinBraverBattle<DownResult>): Animate {
       all(
         param.tdObjects.skyBrightness.brightness(0.3, 100),
         param.tdObjects.illumination.intensity(0.3, 100),
-        delay(1900)
-          .chain(param.attackerSprite.punchToStand())
-          .chain(delay(500)),
+        delay(1900).chain(
+          all(
+            param.attackerSprite.punchToStand().chain(delay(500)),
+            param.tdObjects.skyBrightness.brightness(1, 500),
+            param.tdObjects.illumination.intensity(1, 500),
+          ),
+        ),
         toInitial(param.tdCamera, 100),
         param.defenderTD.damageIndicator.popUp(param.result.damage),
         onStart(() => param.bgm.do(stop)),
         all(param.defenderSprite.knockBack(), delay(600)).chain(
           all(
             param.defenderSprite.down(),
-            param.tdObjects.skyBrightness.brightness(1, 100),
-            param.tdObjects.illumination.intensity(1, 100),
             delay(param.defenderSprite.downImpactDelay).chain(
               all(
                 onStart(() => param.se.play(param.bigExplosion)),

--- a/src/js/td-scenes/battle/animation/game-state/battle/attack/wing-dozer/down.ts
+++ b/src/js/td-scenes/battle/animation/game-state/battle/attack/wing-dozer/down.ts
@@ -27,17 +27,19 @@ export function down(param: WingDozerBattle<DownResult>): Animate {
       all(
         param.tdObjects.skyBrightness.brightness(0.3, 100),
         param.tdObjects.illumination.intensity(0.3, 100),
-        delay(1900)
-          .chain(param.attackerSprite.upperToStand())
-          .chain(delay(500)),
+        delay(1900).chain(
+          all(
+            param.attackerSprite.upperToStand().chain(delay(500)),
+            param.tdObjects.skyBrightness.brightness(1, 500),
+            param.tdObjects.illumination.intensity(1, 500),
+          ),
+        ),
         toInitial(param.tdCamera, 100),
         param.defenderTD.damageIndicator.popUp(param.result.damage),
         onStart(() => param.bgm.do(stop)),
         all(param.defenderSprite.knockBack(), delay(600)).chain(
           all(
             param.defenderSprite.down(),
-            param.tdObjects.skyBrightness.brightness(1, 100),
-            param.tdObjects.illumination.intensity(1, 100),
             delay(param.defenderSprite.downImpactDelay).chain(
               all(
                 onStart(() => param.se.play(param.bigExplosion)),

--- a/src/js/td-scenes/battle/animation/game-state/reflect/lightning/death-lightning.ts
+++ b/src/js/td-scenes/battle/animation/game-state/reflect/lightning/death-lightning.ts
@@ -22,12 +22,12 @@ export const deathLightning = (param: ReflectAnimationParam): Animate =>
         all(param.damaged.sprite.knockBack(), delay(800)).chain(
           all(
             param.damaged.sprite.down(),
-            param.tdObjects.skyBrightness.brightness(1, 500),
-            param.tdObjects.illumination.intensity(1, 500),
             delay(param.damaged.sprite.downImpactDelay).chain(
               all(
                 onStart(() => param.se.play(param.bigExplosion)),
                 shakeY(param.tdCamera),
+                param.tdObjects.skyBrightness.brightness(1, 500),
+                param.tdObjects.illumination.intensity(1, 500),
               ),
             ),
           ),
@@ -36,4 +36,4 @@ export const deathLightning = (param: ReflectAnimationParam): Animate =>
         param.damaged.hud.gauge.hp(param.damaged.state.armdozer.hp),
       ),
     ),
-  );
+  ).chain(delay(200));


### PR DESCRIPTION
This pull request updates several battle animation sequences to improve the timing and synchronization of lighting effects with character actions. The main change is to group the restoration of sky brightness and illumination with the attacker's transition back to a standing pose, ensuring these visual effects happen together rather than sequentially. Additionally, some redundant or misplaced lighting transitions have been removed or relocated for better visual coherence, and a small delay was added at the end of the death lightning animation.

**Battle Animation Synchronization and Visual Improvements**

*Grouped Lighting Restoration with Attacker Actions:*
- In all `down` animation functions (`genesis-braver`, `gran-dozer`, `lightning-dozer`, `neo-landozer`, `shin-braver`, `wing-dozer`), the restoration of `skyBrightness` and `illumination` to normal levels now happens in parallel with the attacker's return to a standing pose, instead of after. This creates a smoother and more synchronized transition. [[1]](diffhunk://#diff-8ef930a1e9484f7dd3156eecbce9bf53a1ffe6fc017988fa5703da3387742795L30-L38) [[2]](diffhunk://#diff-e03485720e8f2e8d0498a94f6ceef8eb374ecb3ae2a3123aa74ad7fb4778f7f7L30-L40) [[3]](diffhunk://#diff-51c219ec6771103b5380e670df82547ee5bbf3ef7078c572f9c0f150517537e4L30-L38) [[4]](diffhunk://#diff-f49147a89fe3aac69a19f6641553efe83621783b38d99a09616526e82c3b3d72L30-L38) [[5]](diffhunk://#diff-33463fd59d8df0fa64134c36cbc6eb320d10c0f5c469bbaf11f33f3392053889L30-L40) [[6]](diffhunk://#diff-50e31a136ac27c995dfb5a2804deca055a685bd10e469d395cf3bf4e701c5aabL30-L40)

*Removal of Redundant Lighting Transitions:*
- The redundant restoration of `skyBrightness` and `illumination` during the defender's down animation has been removed from all affected `down` animation files, preventing duplicate or conflicting visual transitions. [[1]](diffhunk://#diff-8ef930a1e9484f7dd3156eecbce9bf53a1ffe6fc017988fa5703da3387742795L30-L38) [[2]](diffhunk://#diff-e03485720e8f2e8d0498a94f6ceef8eb374ecb3ae2a3123aa74ad7fb4778f7f7L30-L40) [[3]](diffhunk://#diff-51c219ec6771103b5380e670df82547ee5bbf3ef7078c572f9c0f150517537e4L30-L38) [[4]](diffhunk://#diff-f49147a89fe3aac69a19f6641553efe83621783b38d99a09616526e82c3b3d72L30-L38) [[5]](diffhunk://#diff-33463fd59d8df0fa64134c36cbc6eb320d10c0f5c469bbaf11f33f3392053889L30-L40) [[6]](diffhunk://#diff-50e31a136ac27c995dfb5a2804deca055a685bd10e469d395cf3bf4e701c5aabL30-L40)

*Reflect Lightning Animation Adjustments:*
- In the `deathLightning` reflect animation, the restoration of `skyBrightness` and `illumination` is now grouped with the explosion and camera shake, ensuring these effects are properly synchronized with the impact event.
- A short delay (`delay(200)`) was added at the end of the `deathLightning` animation sequence to provide a smoother transition out of the effect.