### PR TITLE
デスアラート演出を改善

### DIFF
--- a/src/js/game-object/death-alert/animation/change-margin.ts
+++ b/src/js/game-object/death-alert/animation/change-margin.ts
@@ -1,0 +1,16 @@
+import { Animate } from "../../../animation/animate";
+import { tween } from "../../../animation/tween";
+import { DeathAlertModel } from "../model/death-alert-model";
+
+/**
+ * マージンを変更する
+ * @param model モデル
+ * @param margin マージン
+ * @param duration アニメーション時間
+ * @returns アニメーション
+ */
+export const changeMargin = (
+  model: DeathAlertModel,
+  margin: number,
+  duration: number,
+): Animate => tween(model, (t) => t.to({ margin }, duration));

--- a/src/js/game-object/death-alert/model/death-alert-model.ts
+++ b/src/js/game-object/death-alert/model/death-alert-model.ts
@@ -6,4 +6,6 @@ export type DeathAlertModel = {
   opacity: number;
   /** ビネットの色 */
   color: Color;
+  /** ビネットのマージン、0から1で指定 */
+  margin: number;
 };

--- a/src/js/game-object/death-alert/model/initial-value.ts
+++ b/src/js/game-object/death-alert/model/initial-value.ts
@@ -8,5 +8,6 @@ export function createInitialValue(): DeathAlertModel {
   return {
     opacity: 0,
     color: { r: 0, g: 0, b: 0 },
+    margin: 0,
   };
 }

--- a/src/js/game-object/death-alert/procedure/start-enemy-alert.ts
+++ b/src/js/game-object/death-alert/procedure/start-enemy-alert.ts
@@ -1,5 +1,6 @@
 import { all } from "../../../animation/all";
 import { changeColor } from "../animation/change-color";
+import { changeMargin } from "../animation/change-margin";
 import { changeOpacity } from "../animation/change-opacity";
 import { ENEMY_DEATH_ALERT_COLOR } from "../color";
 import { DeathAlertProps } from "../props/death-alert-props";
@@ -23,6 +24,7 @@ export const startEnemyAlert = (
   all(
     changeOpacity(props.model, 1, duration),
     changeColor(props.model, ENEMY_DEATH_ALERT_COLOR, 0),
+    changeMargin(props.model, 1, duration),
   ).play({ group: props.tweenGroup });
   props.se.play(props.sounds.chance);
 };

--- a/src/js/game-object/death-alert/procedure/start-player-alert.ts
+++ b/src/js/game-object/death-alert/procedure/start-player-alert.ts
@@ -1,5 +1,6 @@
 import { all } from "../../../animation/all";
 import { changeColor } from "../animation/change-color";
+import { changeMargin } from "../animation/change-margin";
 import { changeOpacity } from "../animation/change-opacity";
 import { PLAYER_DEATH_ALERT_COLOR } from "../color";
 import { DeathAlertProps } from "../props/death-alert-props";
@@ -23,6 +24,7 @@ export const startPlayerAlert = (
   all(
     changeOpacity(props.model, 1, duration),
     changeColor(props.model, PLAYER_DEATH_ALERT_COLOR, 0),
+    changeMargin(props.model, 1, duration),
   ).play({ group: props.tweenGroup });
   props.se.loop(props.sounds.deathAlert);
 };

--- a/src/js/game-object/death-alert/procedure/stop.ts
+++ b/src/js/game-object/death-alert/procedure/stop.ts
@@ -1,3 +1,5 @@
+import { all } from "../../../animation/all";
+import { changeMargin } from "../animation/change-margin";
 import { changeOpacity } from "../animation/change-opacity";
 import { DeathAlertProps } from "../props/death-alert-props";
 
@@ -14,6 +16,11 @@ export const stop = (props: DeathAlertProps, duration: number): void => {
   props.isPlaying = false;
   props.tweenGroup.update();
   props.tweenGroup.removeAll();
-  changeOpacity(props.model, 0, duration).play({ group: props.tweenGroup });
+  all(
+    changeOpacity(props.model, 0, duration),
+    changeMargin(props.model, 0, duration),
+  ).play({
+    group: props.tweenGroup,
+  });
   props.sounds.deathAlert.sound.stop();
 };

--- a/src/js/game-object/death-alert/view/death-alert-view.ts
+++ b/src/js/game-object/death-alert/view/death-alert-view.ts
@@ -95,10 +95,13 @@ const top: MeshTransformCreator = (options) => {
  * @returns 設定
  */
 const bottom: MeshTransformCreator = (options) => {
-  const { rendererDOM, devicePerScale } = options;
+  const { rendererDOM, devicePerScale, margin } = options;
   return {
     x: 0,
-    y: -rendererDOM.clientHeight / 2 + (MESH_HEIGHT / 2) * devicePerScale,
+    y:
+      -rendererDOM.clientHeight / 2 +
+      (MESH_HEIGHT / 2) * devicePerScale -
+      (1 - margin) * MAX_MARGIN * devicePerScale,
     rotation: 0,
   };
 };
@@ -109,9 +112,12 @@ const bottom: MeshTransformCreator = (options) => {
  * @returns 設定
  */
 const right: MeshTransformCreator = (options) => {
-  const { rendererDOM, devicePerScale } = options;
+  const { rendererDOM, devicePerScale, margin } = options;
   return {
-    x: +rendererDOM.clientWidth / 2 - (MESH_HEIGHT / 2) * devicePerScale,
+    x:
+      +rendererDOM.clientWidth / 2 -
+      (MESH_HEIGHT / 2) * devicePerScale +
+      (1 - margin) * MAX_MARGIN * devicePerScale,
     y: 0,
     rotation: Math.PI / 2,
   };
@@ -123,9 +129,12 @@ const right: MeshTransformCreator = (options) => {
  * @returns 設定
  */
 const left: MeshTransformCreator = (options) => {
-  const { rendererDOM, devicePerScale } = options;
+  const { rendererDOM, devicePerScale, margin } = options;
   return {
-    x: -rendererDOM.clientWidth / 2 + (MESH_HEIGHT / 2) * devicePerScale,
+    x:
+      -rendererDOM.clientWidth / 2 +
+      (MESH_HEIGHT / 2) * devicePerScale -
+      (1 - margin) * MAX_MARGIN * devicePerScale,
     y: 0,
     rotation: -Math.PI / 2,
   };

--- a/src/js/game-object/death-alert/view/death-alert-view.ts
+++ b/src/js/game-object/death-alert/view/death-alert-view.ts
@@ -22,6 +22,9 @@ const MESH_HEIGHT = 50 * ADJUST_SCALE;
 /** 最大不透明度 */
 const MAX_OPACITY = 0.6;
 
+/** ビネットの最大マージン */
+const MAX_MARGIN = 20;
+
 /**
  * メッシュを生成する
  * @param texture テクスチャ
@@ -48,6 +51,8 @@ type MeshTransformOptions = {
   devicePerScale: number;
   /** レンダラーのDOM要素 */
   rendererDOM: HTMLElement;
+  /** ビネットのマージン、0から1で指定 */
+  margin: number;
 };
 
 /** メッシュ変換情報 */
@@ -73,10 +78,13 @@ type MeshTransformCreator = (options: MeshTransformOptions) => MeshTransform;
  * @returns 設定
  */
 const top: MeshTransformCreator = (options) => {
-  const { rendererDOM, devicePerScale } = options;
+  const { rendererDOM, devicePerScale, margin } = options;
   return {
     x: 0,
-    y: rendererDOM.clientHeight / 2 - (MESH_HEIGHT / 2) * devicePerScale,
+    y:
+      rendererDOM.clientHeight / 2 -
+      (MESH_HEIGHT / 2) * devicePerScale +
+      (1 - margin) * MAX_MARGIN * devicePerScale,
     rotation: Math.PI,
   };
 };
@@ -195,6 +203,7 @@ export class DeathAlertView {
       const transform = transformCreator({
         rendererDOM: preRender.rendererDOM,
         devicePerScale,
+        margin: model.margin,
       });
       mesh.position.x = transform.x;
       mesh.position.y = transform.y;

--- a/stories/death-alert.stories.ts
+++ b/stories/death-alert.stories.ts
@@ -12,7 +12,7 @@ export const playerDeathAlert = hudGameObjectStory((params) => {
   const alert = new DeathAlert(params);
   delay(1000)
     .chain(onStart(() => alert.startPlayerAlert(200)))
-    .chain(delay(1000))
+    .chain(delay(3000))
     .chain(onStart(() => alert.stop(200)))
     .chain(delay(1000))
     .loop();
@@ -24,7 +24,7 @@ export const enemyDeathAlert = hudGameObjectStory((params) => {
   const alert = new DeathAlert(params);
   delay(1000)
     .chain(onStart(() => alert.startEnemyAlert(200)))
-    .chain(delay(1000))
+    .chain(delay(3000))
     .chain(onStart(() => alert.stop(200)))
     .chain(delay(1000))
     .loop();


### PR DESCRIPTION
This pull request adds a new "margin" property to the death alert effect, enabling animated control of the vignette's margin during alert transitions. The implementation includes model, animation, and view updates to support margin changes, and applies margin animations to both player and enemy death alerts as well as when stopping the alert. The death alert vignette's appearance now smoothly animates the margin, enhancing the visual feedback.

**Death Alert Margin Feature**

- **Model and Initial State Updates**
  * Added a `margin` property (ranging from 0 to 1) to the `DeathAlertModel` and set its initial value to 0. [[1]](diffhunk://#diff-e8e1ef51bf8ae637ff2a3c413d6218ce88e434325b1d571e716c6f27dc9b8259R9-R10) [[2]](diffhunk://#diff-83c1121593f8eddc98d6327591e95451cc7aba0e2bb7e8e3d0478ef057e3143dR11)

- **Animation and Procedure Enhancements**
  * Implemented a new `changeMargin` animation and integrated it into the start and stop procedures for both player and enemy death alerts, so margin animates in sync with opacity and color. [[1]](diffhunk://#diff-17a9ecc42bec84b882129968956ecec9fd7014b12a269466bc4cafdf2835457bR1-R16) [[2]](diffhunk://#diff-b960fcb76bd4206618e97b290d982e95e39ccbb6af4b6761726746f7bdb3ea04R3) [[3]](diffhunk://#diff-b960fcb76bd4206618e97b290d982e95e39ccbb6af4b6761726746f7bdb3ea04R27) [[4]](diffhunk://#diff-7d97f5da8adef55d91ec61aab2e5ea0cff05d69a55a05373410717a29421e4c2R3) [[5]](diffhunk://#diff-7d97f5da8adef55d91ec61aab2e5ea0cff05d69a55a05373410717a29421e4c2R27) [[6]](diffhunk://#diff-929dd588f62a7d135b5598baa114a88a278a9a1813532d62895a0b2d02d45b3aR1-R2) [[7]](diffhunk://#diff-929dd588f62a7d135b5598baa114a88a278a9a1813532d62895a0b2d02d45b3aL17-R24)

- **View and Rendering Logic**
  * Updated the death alert view logic to use the new `margin` property, adjusting mesh transforms for all vignette sides based on the current margin value, and introduced a `MAX_MARGIN` constant. [[1]](diffhunk://#diff-512c1c4bebcb866235ea07f0ab34bab569f7cb790bd3a40716425a8a76e24815R25-R27) [[2]](diffhunk://#diff-512c1c4bebcb866235ea07f0ab34bab569f7cb790bd3a40716425a8a76e24815R54-R55) [[3]](diffhunk://#diff-512c1c4bebcb866235ea07f0ab34bab569f7cb790bd3a40716425a8a76e24815L76-R87) [[4]](diffhunk://#diff-512c1c4bebcb866235ea07f0ab34bab569f7cb790bd3a40716425a8a76e24815L90-R104) [[5]](diffhunk://#diff-512c1c4bebcb866235ea07f0ab34bab569f7cb790bd3a40716425a8a76e24815L104-R120) [[6]](diffhunk://#diff-512c1c4bebcb866235ea07f0ab34bab569f7cb790bd3a40716425a8a76e24815L118-R137) [[7]](diffhunk://#diff-512c1c4bebcb866235ea07f0ab34bab569f7cb790bd3a40716425a8a76e24815R215)

- **Storybook Demo Improvements**
  * Extended the display duration of death alerts in the Storybook demo to better showcase the new margin animation. [[1]](diffhunk://#diff-eba490ef19c860aefad8d4923de0c3548ce0f8d49e6db4b39ad23ca51f62e65fL15-R15) [[2]](diffhunk://#diff-eba490ef19c860aefad8d4923de0c3548ce0f8d49e6db4b39ad23ca51f62e65fL27-R27)